### PR TITLE
Move from flask_restful to flask_restx. Replace error dictionaries with abort

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,5 @@
 from flask import Flask
-from flask_restful import Api
+from flask_restx import Api
 from flask_cors import CORS
 from resources.User import User
 from resources.Login import Login

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ exceptiongroup==1.1.3
 Flask==2.3.2
 Flask-Cors==4.0.0
 Flask-RESTful==0.3.10
+flask-restx==1.3.0
 Flask-SQLAlchemy~=3.1.1
 gotrue==1.0.3
 gunicorn==21.2.0

--- a/resources/Login.py
+++ b/resources/Login.py
@@ -1,3 +1,4 @@
+from flask_restx import abort
 from werkzeug.security import check_password_hash
 from flask import request
 from middleware.login_queries import login_results, create_session_token
@@ -35,4 +36,4 @@ class Login(PsycopgResource):
                 "data": token,
             }
 
-        return {"message": "Invalid email or password"}, 401
+        abort(code=401, message="Invalid email or password")

--- a/resources/PsycopgResource.py
+++ b/resources/PsycopgResource.py
@@ -1,8 +1,7 @@
 import functools
 from typing import Callable, Any, Union, Tuple, Dict
 
-from flask_restful import Resource
-from flask_restx import abort
+from flask_restx import abort, Resource
 
 
 def handle_exceptions(
@@ -43,11 +42,12 @@ def handle_exceptions(
 
 
 class PsycopgResource(Resource):
-    def __init__(self, **kwargs):
+    def __init__(self, *args, **kwargs):
         """
         Initializes the resource with a database connection.
         - kwargs (dict): Keyword arguments containing 'psycopg2_connection' for database connection.
         """
+        super().__init__(*args, **kwargs)
         self.psycopg2_connection = kwargs["psycopg2_connection"]
 
     def get(self):

--- a/resources/PsycopgResource.py
+++ b/resources/PsycopgResource.py
@@ -2,6 +2,7 @@ import functools
 from typing import Callable, Any, Union, Tuple, Dict
 
 from flask_restful import Resource
+from flask_restx import abort
 
 
 def handle_exceptions(
@@ -36,7 +37,7 @@ def handle_exceptions(
         except Exception as e:
             self.psycopg2_connection.rollback()
             print(str(e))
-            return {"message": str(e)}, 500
+            abort(http_status_code=500, message=str(e))
 
     return wrapper
 

--- a/resources/QuickSearch.py
+++ b/resources/QuickSearch.py
@@ -1,3 +1,5 @@
+from flask_restx import abort
+
 from middleware.security import api_required
 from middleware.quick_search_query import quick_search_query
 import requests
@@ -53,10 +55,10 @@ class QuickSearch(PsycopgResource):
                 )
 
             if data_sources["count"] == 0:
-                return {
-                    "count": 0,
-                    "message": "No results found. Please considering requesting a new data source.",
-                }, 404
+                abort(
+                    code=404,
+                    message="No results found. Please considering requesting a new data source.",
+                )
 
             return {
                 "message": "Results for search successfully retrieved",
@@ -82,4 +84,4 @@ class QuickSearch(PsycopgResource):
                 headers={"Content-Type": "application/json"},
             )
 
-            return {"count": 0, "message": user_message}, 500
+            abort(code=500, message=user_message)

--- a/resources/RefreshSession.py
+++ b/resources/RefreshSession.py
@@ -1,4 +1,6 @@
 from flask import request
+from flask_restx import abort
+
 from middleware.login_queries import token_results, create_session_token
 from datetime import datetime as dt
 from typing import Dict, Any
@@ -38,4 +40,4 @@ class RefreshSession(PsycopgResource):
                 "data": token,
             }
 
-        return {"message": "Invalid session token"}, 403
+        abort(code=403, message="Invalid session token")

--- a/resources/ResetPassword.py
+++ b/resources/ResetPassword.py
@@ -1,3 +1,4 @@
+from flask_restx import abort
 from werkzeug.security import generate_password_hash
 from flask import request
 from middleware.reset_token_queries import (
@@ -32,13 +33,13 @@ class ResetPassword(PsycopgResource):
         token_data = check_reset_token(cursor, token)
         email = token_data.get("email")
         if "create_date" not in token_data:
-            return {"message": "The submitted token is invalid"}, 400
+            abort(code=400, message="The submitted token is invalid")
 
         token_create_date = token_data["create_date"]
         token_expired = (dt.utcnow() - token_create_date).total_seconds() > 900
         delete_reset_token(cursor, token_data["email"], token)
         if token_expired:
-            return {"message": "The submitted token is invalid"}, 400
+            abort(code=400, message="The submitted token is invalid")
 
         password_digest = generate_password_hash(password)
         cursor = self.psycopg2_connection.cursor()

--- a/resources/ResetTokenValidation.py
+++ b/resources/ResetTokenValidation.py
@@ -1,4 +1,6 @@
 from flask import request
+from flask_restx import abort
+
 from middleware.reset_token_queries import (
     check_reset_token,
 )
@@ -22,6 +24,6 @@ class ResetTokenValidation(PsycopgResource):
         token_expired = (dt.utcnow() - token_create_date).total_seconds() > 900
 
         if token_expired:
-            return {"message": "The submitted token is invalid"}, 400
+            abort(code=400, message="The submitted token is invalid")
 
         return {"message": "Token is valid"}

--- a/tests/resources/test_RefreshSession.py
+++ b/tests/resources/test_RefreshSession.py
@@ -123,9 +123,7 @@ def test_post_refresh_session_unexpected_error(
     )
 
     check_response_status(response, 500)
-    assert response.json == {
-        "message": "An unexpected error occurred",
-    }
+    assert response.json["message"] == "An unexpected error occurred"
     mock_get_session_token_user_data.assert_called_once_with(
         mock_cursor, "old_test_session_token"
     )


### PR DESCRIPTION
#### Fixes

* None. Quality of life enhancement.
* Obviates https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/276

#### Description

* Replaces all instances of returning error dictionaries with [flask_restx.abort](https://flask-restx.readthedocs.io/en/latest/errors.html) in multiple resources files. This refactoring enhances code readability and simplifies error handling. It also ensures that HTTP errors are handled in a more standardized way across the application.
* Resource class and `Api` usage in `app.py` has transitioned from `flask_restful` to `flask_restx`, which supports automated swagger documentation and has more active support. 

#### Testing

* None. Testing will be encompassed in expanded tests for all modules.

#### Performance

* No expected performance impact. 

#### Docs

* Not applicable. 