### PR TITLE
Mc issue 312 replace http status code when source not found

### DIFF
--- a/resources/DataSources.py
+++ b/resources/DataSources.py
@@ -42,7 +42,7 @@ class DataSourceById(PsycopgResource):
             }
 
         else:
-            return {"message": "Data source not found."}, 404
+            return {"message": "Data source not found."}, 200
 
     @handle_exceptions
     @api_required

--- a/tests/integration/test_data_sources_by_id.py
+++ b/tests/integration/test_data_sources_by_id.py
@@ -24,7 +24,7 @@ def test_data_sources_by_id_get(
         headers={"Authorization": f"Bearer {api_key}"},
     )
     assert response.status_code == 200
-    assert response.json["data"]["homepage_url"] == "http://src1.com"
+    assert response.json["data"]["source_url"] == "http://src1.com"
 
 
 def test_data_sources_by_id_put(

--- a/tests/resources/test_DataSources.py
+++ b/tests/resources/test_DataSources.py
@@ -1,0 +1,40 @@
+# The below line is required to bypass the api_required decorator,
+# and must be positioned prior to other imports in order to work.
+from unittest.mock import patch, MagicMock
+patch("middleware.security.api_required", lambda x: x).start()
+from tests.fixtures import client_with_mock_db
+
+
+@patch("resources.DataSources.data_source_by_id_query")
+def test_get_data_source_by_id_found(
+    mock_data_source_by_id_query,
+    client_with_mock_db,
+):
+    mock_data_source_by_id_query.return_value = {"name": "Test Data Source"}
+    response = client_with_mock_db.get("/data-sources-by-id/test_id")
+    assert response.json == {
+        "message": "Successfully found data source",
+        "data": {"name": "Test Data Source"},
+    }
+    assert response.status_code == 200
+
+
+@patch("resources.DataSources.data_source_by_id_query")
+def test_get_data_source_by_id_not_found(
+    mock_data_source_by_id_query,
+    client_with_mock_db,
+):
+    mock_data_source_by_id_query.return_value = None
+    response = client_with_mock_db.get("/data-sources-by-id/test_id")
+    assert response.json == {"message": "Data source not found."}
+    assert response.status_code == 200
+
+def test_put_data_source_by_id(
+    client_with_mock_db, monkeypatch
+):
+
+    monkeypatch.setattr("resources.DataSources.request", MagicMock())
+    # mock_request.get_json.return_value = {"name": "Updated Data Source"}
+    response = client_with_mock_db.put("/data-sources-by-id/test_id")
+    assert response.status_code == 200
+    assert response.json == {"message": "Data source updated successfully."}


### PR DESCRIPTION
#### Fixes

* https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/312

#### Description

* Fixed response status code for data source not found in the `DataSourceByID` put get method to return 200 instead of 404.
* Add unit tests for getting and updating data sources by ID in `test_DataSources.py`
* Fix typo in assertion for data source URL in `test_data_sources_by_id` integration test, causing it not to pass.


#### Testing

* `tests/resources/test_DataSources.py`
* `tests/integration/test_data_sources_by_id.py`

#### Performance

* Some additional test overhead, less than one second.

#### Docs

* Not applicable.