### PR TITLE
Fixed create_test_user so that email is set to a random email if not …

### DIFF
--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -103,7 +103,7 @@ def create_reset_token(cursor: psycopg2.extensions.cursor) -> TestTokenInsert:
 
 def create_test_user(
     cursor,
-    email="example@example.com",
+    email="",
     password_hash="hashed_password_here",
     api_key="api_key_here",
     role=None,
@@ -114,6 +114,8 @@ def create_test_user(
     :param cursor:
     :return: user id
     """
+    if email == "":
+        email = uuid.uuid4().hex + "@test.com"
     cursor.execute(
         """
         INSERT INTO users (email, password_digest, api_key, role)


### PR DESCRIPTION
#### Fixes

* None. Improvement to testing

#### Description

* A bug existed in the `tests/helper_functions/create_test_user()` method, which created the same test email for insertion into the users database. When test results are not reversed after the tests (as is currently the case sometimes) this creates a unique constraint violation and causes any associated test to fail. 
* The helper function has been updated such that a random username is generated. 
* Ideally, all tests will reverse themselves, and that is an ultimate goal, but this at least prevents tests from failing for reasons outside of their intended logic.

#### Testing

* Run all tests in `integration`, `middleware`, and `resources` subdirectories -- check that any which fail do not mention the unique email constraint for the `users` table.

#### Performance

* Performance impact marginal. May have an impact on database pollution if too many users are added at once, but since the dev database refreshes daily, this is of limited risk.

#### Docs

* Not applicable. 