### PR TITLE
Mc issue 290 remove datetime of request

### DIFF
--- a/middleware/quick_search_query.py
+++ b/middleware/quick_search_query.py
@@ -52,7 +52,7 @@ QUICK_SEARCH_SQL = """
 
 """
 
-INSERT_LOG_QUERY = "INSERT INTO quick_search_query_logs (search, location, results, result_count, created_at, datetime_of_request) VALUES ('{0}', '{1}', '{2}', '{3}', '{4}', '{4}')"
+INSERT_LOG_QUERY = "INSERT INTO quick_search_query_logs (search, location, results, result_count) VALUES ('{0}', '{1}', '{2}', '{3}')"
 
 
 def unaltered_search_query(
@@ -148,14 +148,11 @@ def quick_search_query(
         "data": data_source_matches_converted,
     }
 
-    current_datetime = datetime.datetime.now()
-    datetime_string = current_datetime.strftime("%Y-%m-%d %H:%M:%S")
-
     query_results = json.dumps(data_sources["data"]).replace("'", "")
 
     cursor.execute(
         INSERT_LOG_QUERY.format(
-            search, location, query_results, data_sources["count"], datetime_string
+            search, location, query_results, data_sources["count"]
         ),
     )
     conn.commit()

--- a/resources/QuickSearch.py
+++ b/resources/QuickSearch.py
@@ -41,12 +41,6 @@ class QuickSearch(PsycopgResource):
             )
 
             if data_sources["count"] == 0:
-                self.psycopg2_connection = initialize_psycopg2_connection()
-                data_sources = quick_search_query(
-                    search, location, self.psycopg2_connection
-                )
-
-            if data_sources["count"] == 0:
                 return {
                     "count": 0,
                     "message": "No results found. Please considering requesting a new data source.",

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -151,8 +151,8 @@ def get_most_recent_quick_search_query_log(
     """
     cursor.execute(
         """
-        SELECT RESULT_COUNT, DATETIME_OF_REQUEST FROM QUICK_SEARCH_QUERY_LOGS WHERE
-        search = %s AND location = %s ORDER BY DATETIME_OF_REQUEST DESC LIMIT 1
+        SELECT RESULT_COUNT, CREATED_AT FROM QUICK_SEARCH_QUERY_LOGS WHERE
+        search = %s AND location = %s ORDER BY CREATED_AT DESC LIMIT 1
         """,
         (search, location),
     )

--- a/tests/integration/test_search_tokens.py
+++ b/tests/integration/test_search_tokens.py
@@ -22,8 +22,8 @@ def test_search_tokens_get(
     assert response.status_code == 200
     data = response.json.get("data")
     assert (
-        data["count"] == 1
+        len(data) == 1
     ), "Quick Search endpoint response should return only one entry"
-    entry = data["data"][0]
+    entry = data[0]
     assert entry["agency_name"] == "Agency A"
     assert entry["airtable_uid"] == "SOURCE_UID_1"

--- a/tests/resources/test_QuickSearch.py
+++ b/tests/resources/test_QuickSearch.py
@@ -1,0 +1,38 @@
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from tests.helper_functions import check_response_status
+
+patch("middleware.security.api_required", lambda x: x).start()
+from tests.fixtures import client_with_mock_db
+
+@pytest.fixture
+def mock_quick_search_query(monkeypatch):
+    mock = MagicMock()
+    monkeypatch.setattr("resources.QuickSearch.quick_search_query", mock)
+    return mock
+
+
+def test_get_quick_search_results_found(client_with_mock_db, mock_quick_search_query):
+    mock_quick_search_query.return_value = {
+        "count": "1",
+        "data": [{"id": "test_id", "name": "test_name"}],
+    }
+    response = client_with_mock_db.client.get("/quick-search/test_search/test_location")
+    check_response_status(response, 200)
+    response_json = response.json
+    assert response_json["data"]["data"] == [{'id': 'test_id', 'name': 'test_name'}]
+    assert response_json["data"]["count"] == '1'
+    assert response_json["message"] == "Results for search successfully retrieved"
+
+def test_get_quick_search_results_not_found(client_with_mock_db, mock_quick_search_query):
+    mock_quick_search_query.return_value = {
+        "count": 0,
+        "data": [],
+    }
+    response = client_with_mock_db.client.get("/quick-search/test_search/test_location")
+    check_response_status(response, 404)
+    response_json = response.json
+    assert response_json["count"] == 0
+    assert response_json["message"] == "No results found. Please considering requesting a new data source."


### PR DESCRIPTION
#### Fixes

* https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/290

#### Description

* Fix bug in QuickSearch where old `datetime_of_request` field was being referenced, and `created_at` field was having data inserted into it. Thanks to changes in the database (also discussed in the issue above) these are no longer necessary.
* Add resource tests in `tests/resources/test_QuickSearch.py

#### Testing

* Run relevant quicksearch tests in all test locations

#### Performance

* Additional test overhead

#### Docs

* Not applicable. 