### PR TITLE
⚙️ Adjust status code for data source not found response

### DIFF
--- a/middleware/data_source_queries.py
+++ b/middleware/data_source_queries.py
@@ -110,7 +110,7 @@ def data_source_by_id_wrapper(arg, conn: PgConnection) -> Response:
         return make_response(data_source_details, 200)
 
     else:
-        return make_response({"message": "Data source not found."}, 404)
+        return make_response({"message": "Data source not found."}, 200)
 
 
 def get_data_sources_for_map_wrapper(conn: PgConnection):

--- a/tests/middleware/test_data_source_queries.py
+++ b/tests/middleware/test_data_source_queries.py
@@ -188,4 +188,4 @@ def test_data_source_by_id_wrapper_data_not_found(mock_data_source_by_id_query, 
     mock_data_source_by_id_query.assert_called_with(
         data_source_id="SOURCE_UID_1", conn=mock_conn
     )
-    mock_make_response.assert_called_with({"message": "Data source not found."}, 404)
+    mock_make_response.assert_called_with({"message": "Data source not found."}, 200)


### PR DESCRIPTION
ℹ️ Fix the status code returned when a data source is not found to be 200 instead of 404 in middleware/data_source_queries.py and tests/middleware/test_data_source_queries.py, per https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/312

This had been previously addressed, but merging a different branch caused this logic to revert. 

