### PR TITLE
Fix casing search issue - v2 patch

### DIFF
--- a/middleware/quick_search_query.py
+++ b/middleware/quick_search_query.py
@@ -51,10 +51,10 @@ QUICK_SEARCH_SQL = """
     INNER JOIN
         state_names ON agencies.state_iso = state_names.state_iso
     WHERE
-        (data_sources.name LIKE '%{0}%' OR data_sources.description LIKE '%{0}%' OR data_sources.record_type LIKE '%{0}%' OR data_sources.tags LIKE '%{0}%') 
-        AND (agencies.county_name LIKE '%{1}%' OR substr(agencies.county_name,3,length(agencies.county_name)-4) || ' County' LIKE '%{1}%' 
-            OR agencies.state_iso LIKE '%{1}%' OR agencies.municipality LIKE '%{1}%' OR agencies.agency_type LIKE '%{1}%' OR agencies.jurisdiction_type LIKE '%{1}%' 
-            OR agencies.name LIKE '%{1}%' OR state_names.state_name LIKE '%{1}%')
+        (data_sources.name ILIKE '%{0}%' OR data_sources.description ILIKE '%{0}%' OR data_sources.record_type ILIKE '%{0}%' OR data_sources.tags ILIKE '%{0}%') 
+        AND (agencies.county_name ILIKE '%{1}%' OR substr(agencies.county_name,3,length(agencies.county_name)-4) || ' County' ILIKE '%{1}%' 
+            OR agencies.state_iso ILIKE '%{1}%' OR agencies.municipality ILIKE '%{1}%' OR agencies.agency_type ILIKE '%{1}%' OR agencies.jurisdiction_type ILIKE '%{1}%' 
+            OR agencies.name ILIKE '%{1}%' OR state_names.state_name ILIKE '%{1}%')
         AND data_sources.approval_status = 'approved'
         AND data_sources.url_status not in ('broken', 'none found')
 
@@ -79,7 +79,7 @@ def unaltered_search_query(
     :return: A list of dictionaries representing the search results.
     """
     print(f"Query parameters: '%{search}%', '%{location}%'")
-    cursor.execute(QUICK_SEARCH_SQL.format(search.title(), location.title()))
+    cursor.execute(QUICK_SEARCH_SQL.format(search, location))
     results = cursor.fetchall()
 
     return results
@@ -103,7 +103,7 @@ def spacy_search_query(
     print(f"Query parameters: '%{depluralized_search_term}%', '%{location}%'")
 
     cursor.execute(
-        QUICK_SEARCH_SQL.format(depluralized_search_term.title(), location.title())
+        QUICK_SEARCH_SQL.format(depluralized_search_term, location)
     )
     results = cursor.fetchall()
 


### PR DESCRIPTION
#### Fixes

* https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/346

#### Description

* The quick search terms were previously case sensitive, causing some results to be excluded
* Removes `.title()` function that was previously applied to the search terms
* Changes the SQL query from `LIKE` to `ILIKE` (case-insensitive `LIKE`)
* `ILIKE` is a PSQL keyword similar to using `UPPER()` or `LOWER()` for case insensitive matching in other SQL versions. Read more about it here: https://www.postgresql.org/docs/current/functions-matching.html#FUNCTIONS-LIKE

![image](https://github.com/Police-Data-Accessibility-Project/data-sources-app-v2/assets/84819232/2ba044f7-c1ab-4c8b-b637-2e16e80bd522)
![image](https://github.com/Police-Data-Accessibility-Project/data-sources-app-v2/assets/84819232/63c6c418-6c37-41fc-abbe-68957a47abe2)

#### Testing

* Checkout the branch
* Setup testing environment like normal
* Search using terms outlined in issue [346](https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/346) and confirm the results are now returned properly