### PR TITLE
Mc issue 345 typeahead

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,7 +3,10 @@ import os
 from flask import Flask
 from flask_cors import CORS
 
-from resources.TypeaheadSuggestions import TypeaheadSuggestions
+from resources.TypeaheadSuggestions import (
+    TypeaheadSuggestions,
+    namespace_typeahead_suggestions,
+)
 from flask_restx import Api
 
 from config import config
@@ -34,6 +37,7 @@ NAMESPACES = [
     namespace_refresh_session,
     namespace_reset_password,
     namespace_quick_search,
+    namespace_typeahead_suggestions,
 ]
 
 MY_PREFIX = "/api"

--- a/app.py
+++ b/app.py
@@ -1,6 +1,8 @@
 from flask import Flask
 from flask_restx import Api
 from flask_cors import CORS
+
+from resources.TypeaheadSuggestions import TypeaheadSuggestions
 from resources.User import User
 from resources.Login import Login
 from resources.RefreshSession import RefreshSession
@@ -47,6 +49,7 @@ def create_app() -> Flask:
         (DataSourceById, "/data-sources-by-id/<data_source_id>"),
         (Agencies, "/agencies/<page>"),
         (SearchTokens, "/search-tokens"),
+        (TypeaheadSuggestions, "/typeahead-suggestions"),
     ]
 
     for resource, endpoint in resources:

--- a/middleware/typeahead_suggestion_logic.py
+++ b/middleware/typeahead_suggestion_logic.py
@@ -1,0 +1,16 @@
+from http import HTTPStatus
+
+from flask import Response, make_response
+
+from database_client.database_client import DatabaseClient
+
+
+def get_typeahead_dict_results(suggestions: list[DatabaseClient.TypeaheadSuggestions]) -> list[dict]:
+    return [suggestion._asdict() for suggestion in suggestions]
+
+def get_typeahead_suggestions_wrapper(
+    db_client: DatabaseClient, query: str
+) -> Response:
+    suggestions = db_client.get_typeahead_suggestions(query)
+    dict_results = get_typeahead_dict_results(suggestions)
+    return make_response(dict_results, HTTPStatus.OK)

--- a/middleware/typeahead_suggestion_logic.py
+++ b/middleware/typeahead_suggestion_logic.py
@@ -13,4 +13,5 @@ def get_typeahead_suggestions_wrapper(
 ) -> Response:
     suggestions = db_client.get_typeahead_suggestions(query)
     dict_results = get_typeahead_dict_results(suggestions)
-    return make_response(dict_results, HTTPStatus.OK)
+    return make_response(
+        {"suggestions": dict_results}, HTTPStatus.OK)

--- a/resources/TypeaheadSuggestions.py
+++ b/resources/TypeaheadSuggestions.py
@@ -1,14 +1,81 @@
 from flask import Response, request
+from flask_restx import fields, reqparse
 
 from middleware.typeahead_suggestion_logic import get_typeahead_suggestions_wrapper
 from resources.PsycopgResource import handle_exceptions, PsycopgResource
 
+from utilities.namespace import create_namespace, AppNamespaces
 
+namespace_typeahead_suggestions = create_namespace(
+    namespace_attributes=AppNamespaces.SEARCH
+)
+
+request_parser = reqparse.RequestParser()
+request_parser.add_argument(
+    "query",
+    type=str,
+    location="args",
+    required=True,
+    help="The typeahead query to get suggestions for, such as `Pitts`",
+)
+
+typeahead_suggestions_inner_model = namespace_typeahead_suggestions.model(
+    "TypeaheadSuggestionsInner",
+    {
+        "display_name": fields.String(
+            required=True,
+            description="The display name of the suggestion",
+            example="Pittsburgh",),
+        "type": fields.String(
+            required=True,
+            description="The type of suggestion. Either `State`, `County` or `Locality`",
+            example="Locality",
+        ),
+        "state": fields.String(
+            required=True,
+            description="The state of the suggestion",
+            example="Pennsylvania",
+        ),
+        "county": fields.String(
+            required=True,
+            description="The county of the suggestion",
+            example="Allegheny",
+        ),
+        "locality": fields.String(
+            required=True,
+            description="The locality of the suggestion",
+            example="Pittsburgh",
+        ),
+    },
+)
+
+typeahead_suggestions_outer_model = namespace_typeahead_suggestions.model(
+    "TypeaheadSuggestionsOuter",
+    {
+        "suggestions": fields.List(
+            fields.Nested(typeahead_suggestions_inner_model),
+            description="A list of suggestions",
+        ),
+    },
+)
+
+
+@namespace_typeahead_suggestions.route("/typeahead-suggestions")
 class TypeaheadSuggestions(PsycopgResource):
 
     @handle_exceptions
+    @namespace_typeahead_suggestions.expect(request_parser)
+    @namespace_typeahead_suggestions.response(200, "OK", typeahead_suggestions_outer_model)
+    @namespace_typeahead_suggestions.response(500, "Internal server error")
     def get(self) -> Response:
-        data = request.get_json()
+        """
+        Get suggestions for a typeahead query
+        Queries the database for typeahead suggestions of locations
+
+        **Returns**
+            - a list of location suggestions
+        """
+        query = request.args.get("query")
         with self.setup_database_client() as db_client:
-            response = get_typeahead_suggestions_wrapper(db_client, data.get("query"))
+            response = get_typeahead_suggestions_wrapper(db_client, query)
         return response

--- a/resources/TypeaheadSuggestions.py
+++ b/resources/TypeaheadSuggestions.py
@@ -1,0 +1,14 @@
+from flask import Response, request
+
+from middleware.typeahead_suggestion_logic import get_typeahead_suggestions_wrapper
+from resources.PsycopgResource import handle_exceptions, PsycopgResource
+
+
+class TypeaheadSuggestions(PsycopgResource):
+
+    @handle_exceptions
+    def get(self) -> Response:
+        data = request.get_json()
+        with self.setup_database_client() as db_client:
+            response = get_typeahead_suggestions_wrapper(db_client, data.get("query"))
+        return response

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -400,6 +400,6 @@ def setup_get_typeahead_suggestion_test_data(cursor: psycopg2.extensions.cursor)
         )
 
         # Refresh materialized view
-        cursor.execute("REFRESH MATERIALIZED VIEW typeahead_suggestions;")
+        cursor.execute("CALL refresh_typeahead_suggestions();")
     except psycopg2.errors.UniqueViolation:
         cursor.execute("ROLLBACK TO SAVEPOINT typeahead_suggestion_test_savepoint")

--- a/tests/integration/test_typeahead_suggestions.py
+++ b/tests/integration/test_typeahead_suggestions.py
@@ -1,0 +1,35 @@
+from http import HTTPStatus
+
+from tests.helper_functions import (
+    check_response_status,
+    setup_get_typeahead_suggestion_test_data,
+)
+from tests.fixtures import client_with_db, dev_db_connection
+
+
+def test_typeahead_suggestions(client_with_db, dev_db_connection):
+    """
+    Test that GET call to /typeahead-suggestions endpoint successfully retrieves data
+    """
+    setup_get_typeahead_suggestion_test_data(dev_db_connection.cursor())
+    dev_db_connection.commit()
+    response = client_with_db.get("/typeahead-suggestions", json={"query": "xyl"})
+    check_response_status(response, HTTPStatus.OK.value)
+    results = response.json
+    assert results[0]["display_name"] == "Xylodammerung"
+    assert results[0]["locality"] == "Xylodammerung"
+    assert results[0]["county"] == "Arxylodon"
+    assert results[0]["state"] == "Xylonsylvania"
+    assert results[0]["type"] == "Locality"
+
+    assert results[1]["display_name"] == "Xylonsylvania"
+    assert results[1]["locality"] is None
+    assert results[1]["county"] is None
+    assert results[1]["state"] == "Xylonsylvania"
+    assert results[1]["type"] == "State"
+
+    assert results[2]["display_name"] == "Arxylodon"
+    assert results[2]["locality"] is None
+    assert results[2]["county"] == "Arxylodon"
+    assert results[2]["state"] == "Xylonsylvania"
+    assert results[2]["type"] == "County"

--- a/tests/integration/test_typeahead_suggestions.py
+++ b/tests/integration/test_typeahead_suggestions.py
@@ -13,9 +13,9 @@ def test_typeahead_suggestions(client_with_db, dev_db_connection):
     """
     setup_get_typeahead_suggestion_test_data(dev_db_connection.cursor())
     dev_db_connection.commit()
-    response = client_with_db.get("/typeahead-suggestions", json={"query": "xyl"})
+    response = client_with_db.get("/search/typeahead-suggestions?query=xyl")
     check_response_status(response, HTTPStatus.OK.value)
-    results = response.json
+    results = response.json["suggestions"]
     assert results[0]["display_name"] == "Xylodammerung"
     assert results[0]["locality"] == "Xylodammerung"
     assert results[0]["county"] == "Arxylodon"

--- a/tests/middleware/test_typeahead_suggestion_logic.py
+++ b/tests/middleware/test_typeahead_suggestion_logic.py
@@ -81,4 +81,4 @@ def test_get_typeahead_suggestions_wrapper(monkeypatch):
     get_typeahead_suggestions_wrapper(mock_db_client, mock_query)
     mock_db_client.get_typeahead_suggestions.assert_called_with(mock_query)
     mock_get_typeahead_dict_results.assert_called_with(mock_suggestions)
-    mock_make_response.assert_called_with(mock_dict_results, HTTPStatus.OK)
+    mock_make_response.assert_called_with({"suggestions": mock_dict_results}, HTTPStatus.OK)

--- a/tests/middleware/test_typeahead_suggestion_logic.py
+++ b/tests/middleware/test_typeahead_suggestion_logic.py
@@ -1,0 +1,84 @@
+from http import HTTPStatus
+from unittest.mock import MagicMock
+
+import pytest
+
+from database_client.database_client import DatabaseClient
+from middleware.typeahead_suggestion_logic import (
+    get_typeahead_dict_results,
+    get_typeahead_suggestions_wrapper,
+)
+
+
+def test_get_typeahead_dict_results():
+    mock_suggestions = [
+        DatabaseClient.TypeaheadSuggestions(
+            display_name="display_name_1",
+            type="type_1",
+            state="state_1",
+            county="county_1",
+            locality="locality_1",
+        ),
+        DatabaseClient.TypeaheadSuggestions(
+            display_name="display_name_2",
+            type="type_2",
+            state="state_2",
+            county="county_2",
+            locality="locality_2",
+        ),
+        DatabaseClient.TypeaheadSuggestions(
+            display_name="display_name_3",
+            type="type_3",
+            state="state_3",
+            county="county_3",
+            locality="locality_3",
+        ),
+    ]
+
+    expected_results = [
+        {
+            "display_name": "display_name_1",
+            "type": "type_1",
+            "state": "state_1",
+            "county": "county_1",
+            "locality": "locality_1",
+        },
+        {
+            "display_name": "display_name_2",
+            "type": "type_2",
+            "state": "state_2",
+            "county": "county_2",
+            "locality": "locality_2",
+        },
+        {
+            "display_name": "display_name_3",
+            "type": "type_3",
+            "state": "state_3",
+            "county": "county_3",
+            "locality": "locality_3",
+        },
+    ]
+
+    assert get_typeahead_dict_results(mock_suggestions) == expected_results
+
+
+def test_get_typeahead_suggestions_wrapper(monkeypatch):
+    mock_db_client = MagicMock()
+    mock_query = MagicMock()
+    mock_suggestions = MagicMock()
+    mock_db_client.get_typeahead_suggestions.return_value = mock_suggestions
+    mock_dict_results = MagicMock()
+    mock_get_typeahead_dict_results = MagicMock(return_value=mock_dict_results)
+    monkeypatch.setattr(
+        "middleware.typeahead_suggestion_logic.get_typeahead_dict_results",
+        mock_get_typeahead_dict_results,
+    )
+    mock_make_response = MagicMock()
+    monkeypatch.setattr(
+        "middleware.typeahead_suggestion_logic.make_response", mock_make_response
+    )
+
+    get_typeahead_suggestions_wrapper(mock_db_client, mock_query)
+    mock_db_client.get_typeahead_suggestions.assert_called_with(mock_query)
+    mock_get_typeahead_dict_results.assert_called_with(mock_suggestions)
+    mock_make_response.assert_called_with(mock_dict_results, HTTPStatus.OK)

--- a/tests/resources/test_TypeaheadSuggestions.py
+++ b/tests/resources/test_TypeaheadSuggestions.py
@@ -5,16 +5,12 @@ from tests.fixtures import client_with_mock_db, bypass_api_required
 from tests.helper_functions import check_response_status
 
 def test_get_typeahead_suggestions(client_with_mock_db, monkeypatch, bypass_api_required):
-    mock_data = {"query": "test_query"}
-    mock_request = MagicMock()
-    mock_request.get_json.return_value = mock_data
-
     mock_response = ({"message": "Test Response"}, HTTPStatus.IM_A_TEAPOT)
 
     mock_get_typeahead_suggestions = MagicMock(return_value=mock_response)
     monkeypatch.setattr("resources.TypeaheadSuggestions.get_typeahead_suggestions_wrapper", mock_get_typeahead_suggestions)
 
-    response = client_with_mock_db.client.get("/typeahead-suggestions", json=mock_data)
+    response = client_with_mock_db.client.get("/search/typeahead-suggestions?query=test_query")
 
     check_response_status(response, HTTPStatus.IM_A_TEAPOT)
     assert response.json == {"message": "Test Response"}

--- a/tests/resources/test_TypeaheadSuggestions.py
+++ b/tests/resources/test_TypeaheadSuggestions.py
@@ -1,0 +1,20 @@
+from http import HTTPStatus
+from unittest.mock import MagicMock
+
+from tests.fixtures import client_with_mock_db, bypass_api_required
+from tests.helper_functions import check_response_status
+
+def test_get_typeahead_suggestions(client_with_mock_db, monkeypatch, bypass_api_required):
+    mock_data = {"query": "test_query"}
+    mock_request = MagicMock()
+    mock_request.get_json.return_value = mock_data
+
+    mock_response = ({"message": "Test Response"}, HTTPStatus.IM_A_TEAPOT)
+
+    mock_get_typeahead_suggestions = MagicMock(return_value=mock_response)
+    monkeypatch.setattr("resources.TypeaheadSuggestions.get_typeahead_suggestions_wrapper", mock_get_typeahead_suggestions)
+
+    response = client_with_mock_db.client.get("/typeahead-suggestions", json=mock_data)
+
+    check_response_status(response, HTTPStatus.IM_A_TEAPOT)
+    assert response.json == {"message": "Test Response"}

--- a/tests/test_database_client.py
+++ b/tests/test_database_client.py
@@ -16,6 +16,7 @@ from tests.fixtures import live_database_client, dev_db_connection, db_cursor
 from tests.helper_functions import (
     insert_test_agencies_and_sources,
     insert_test_agencies_and_sources_if_not_exist,
+    setup_get_typeahead_suggestion_test_data,
 )
 
 
@@ -374,7 +375,6 @@ def test_delete_session_token(live_database_client):
     assert live_database_client.get_session_token_info(session_token) is None
 
 
-
 def test_get_access_token(live_database_client):
     # Add a new access token to the database
     live_database_client.add_new_access_token(
@@ -416,3 +416,33 @@ def test_delete_expired_access_tokens(live_database_client):
         with pytest.raises(AccessTokenNotFoundError):
             live_database_client.get_access_token(api_key=token)
     assert live_database_client.get_access_token(api_key=unexpired_token)
+
+
+def test_get_typeahead_suggestion(live_database_client):
+    # Insert test data into the database
+    cursor = live_database_client.cursor
+    setup_get_typeahead_suggestion_test_data(cursor)
+
+    # Call the get_typeahead_suggestion function
+    results = live_database_client.get_typeahead_suggestions(search_term="xyl")
+
+    # Check that the results are as expected
+    assert len(results) == 3
+
+    assert results[0].display_name == "Xylodammerung"
+    assert results[0].type == "Locality"
+    assert results[0].state == "Xylonsylvania"
+    assert results[0].county == "Arxylodon"
+    assert results[0].locality == "Xylodammerung"
+
+    assert results[1].display_name == "Xylonsylvania"
+    assert results[1].type == "State"
+    assert results[1].state == "Xylonsylvania"
+    assert results[1].county is None
+    assert results[1].locality is None
+
+    assert results[2].display_name == "Arxylodon"
+    assert results[2].type == "County"
+    assert results[2].state == "Xylonsylvania"
+    assert results[2].county == "Arxylodon"
+    assert results[2].locality is None

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -28,6 +28,7 @@ from resources.RequestResetPassword import RequestResetPassword
 from resources.ResetPassword import ResetPassword
 from resources.ResetTokenValidation import ResetTokenValidation
 from resources.SearchTokens import SearchTokens
+from resources.TypeaheadSuggestions import TypeaheadSuggestions
 from resources.User import User
 from tests.fixtures import client_with_mock_db, ClientWithMockDB
 
@@ -78,6 +79,7 @@ test_parameters = [
     TestParameters(DataSourceById, "/data-sources-by-id/<data_source_id>", [GET, PUT]),
     TestParameters(Agencies, "/agencies/<page>", [GET]),
     TestParameters(SearchTokens, "/search-tokens", [GET]),
+    TestParameters(TypeaheadSuggestions, "/typeahead-suggestions", [GET]),
 ]
 
 

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -79,7 +79,7 @@ test_parameters = [
     TestParameters(DataSourceById, "/data-sources-by-id/<data_source_id>", [GET, PUT]),
     TestParameters(Agencies, "/agencies/<page>", [GET]),
     TestParameters(SearchTokens, "/search-tokens", [GET]),
-    TestParameters(TypeaheadSuggestions, "/typeahead-suggestions", [GET]),
+    TestParameters(TypeaheadSuggestions, "/search/typeahead-suggestions", [GET]),
 ]
 
 

--- a/utilities/namespace.py
+++ b/utilities/namespace.py
@@ -1,13 +1,25 @@
 from flask_restx import Namespace
+from enum import Enum
+from collections import namedtuple
 
-def create_namespace() -> Namespace:
+NamespaceAttributes = namedtuple("NamespaceAttributes", ["path", "description"])
+
+
+class AppNamespaces(Enum):
+    DEFAULT = NamespaceAttributes(path="/", description="Default Namespace")
+    SEARCH = NamespaceAttributes(path="search", description="Search Namespace")
+
+
+def create_namespace(namespace_attributes: AppNamespaces = AppNamespaces.DEFAULT) -> Namespace:
     """
-    Create a default namespace to be used with Flask_restx resources.
+    Create a namespace to be used with Flask_restx resources.
     Each namespace can contain the route definitions and other documentation about the resource
     which can then be imported into the API in the create_app function.
     :return:
     """
 
-    namespace = Namespace("/", description="Default Namespace")
+    path = namespace_attributes.value.path
+    description = namespace_attributes.value.description
+    namespace = Namespace(path, description=description)
 
     return namespace


### PR DESCRIPTION
#### Fixes

* https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/345

#### Description

* Creates first draft of Typeahead Suggestion Endpoint, which will produce up to 4 suggestions based on the content of the search query.
* Note that this PR is dependent on #46 , and that PR should be merged first prior to this one.

#### Testing

* Typeahead Suggestion Tests have been added as separate files to the following `tests` directories: `integration`, `middleware`, `resources`
* Tests have also been added to the following scripts: `test_db_client.py`, `test_endpoints.py`
* Run these tests (as well as all other tests) to confirm functionality. 

#### Performance

* Additional test overhead
* The time to run `integration/test_typeahead_suggestions`, which I'm assuming most closely approximates the runtime of the endpoint in action, was recorded as 297ms.

#### Docs

* https://app.gitbook.com/o/-MXypK5ySzExtEzQU6se/s/-MXyolqTg_voOhFyAcr-/~/changes/508/api/endpoints/data-sources-database#search-v2