### PR TITLE
Add Python version Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![Python Version](https://img.shields.io/badge/python-3.11-blue?style=for-the-badge&logo=python&logoColor=ffdd54)
+
 # data-sources-app-v2
 
 Development of the next big iteration of the data sources app according to https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/248


### PR DESCRIPTION
#### Fixes

* https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/341

#### Description

* Adds Python version badge at top of root README, clearly indicating Python 3.11 is required.

#### Testing

* Look 👁️

#### Performance

* Not applicable. 

#### Docs

* Not applicable.