### PR TITLE
Archive info database overhaul

### DIFF
--- a/database_client/constants.py
+++ b/database_client/constants.py
@@ -68,7 +68,7 @@ ARCHIVE_INFO_APPROVED_COLUMNS = [
     "update_frequency",
     "last_cached",
 ]
-DATA_SOURCES_OUTPUT_COLUMNS = DATA_SOURCES_APPROVED_COLUMNS + ["agency_name"]
+DATA_SOURCES_OUTPUT_COLUMNS = DATA_SOURCES_APPROVED_COLUMNS + ARCHIVE_INFO_APPROVED_COLUMNS + ["agency_name"]
 RESTRICTED_DATA_SOURCE_COLUMNS = [
     "rejection_note",
     "data_source_request",

--- a/database_client/constants.py
+++ b/database_client/constants.py
@@ -44,7 +44,6 @@ DATA_SOURCES_APPROVED_COLUMNS = [
     "access_type",
     "data_portal_type",
     "record_format",
-    "update_frequency",
     "update_method",
     "tags",
     "readme_url",
@@ -64,6 +63,9 @@ DATA_SOURCES_APPROVED_COLUMNS = [
     "url_button",
     "tags_other",
     "access_notes",
+]
+ARCHIVE_INFO_APPROVED_COLUMNS = [
+    "update_frequency",
     "last_cached",
 ]
 DATA_SOURCES_OUTPUT_COLUMNS = DATA_SOURCES_APPROVED_COLUMNS + ["agency_name"]

--- a/database_client/database_client.py
+++ b/database_client/database_client.py
@@ -406,13 +406,17 @@ class DatabaseClient:
         """
         sql_query = """
         SELECT
-            airtable_uid,
-            source_url,
-            update_frequency,
-            last_cached,
-            broken_source_url_as_of
+            data_sources.airtable_uid,
+            data_sources.source_url as source_url,
+            data_sources_archive_info.update_frequency as update_frequency,
+            data_sources_archive_info.last_cached as last_cached,
+            data_sources.broken_source_url_as_of as broken_source_url_as_of
         FROM
             data_sources
+        FULL JOIN
+            data_sources_archive_info
+        ON
+            data_sources.airtable_uid = data_sources_archive_info.airtable_uid
         WHERE 
             (last_cached IS NULL OR update_frequency IS NOT NULL) AND broken_source_url_as_of IS NULL AND url_status <> 'broken' AND source_url IS NOT NULL
         """
@@ -447,18 +451,17 @@ class DatabaseClient:
             data={
                 "url_status": "broken",
                 "broken_source_url_as_of": broken_as_of,
-                "last_cached": last_cached,
             },
         )
 
     def update_last_cached(self, id: str, last_cached: str) -> None:
         """
-        Updates the last_cached field in the data_sources table for a given id.
+        Updates the last_cached field in the data_sources_archive_info table for a given id.
 
         :param id: The airtable_uid of the data source.
         :param last_cached: The last cached date to be updated.
         """
-        sql_query = "UPDATE data_sources SET last_cached = %s WHERE airtable_uid = %s"
+        sql_query = "UPDATE data_sources_archive_info SET last_cached = %s WHERE airtable_uid = %s"
         self.cursor.execute(sql_query, (last_cached, id))
 
     QuickSearchResult = namedtuple(

--- a/database_client/database_client.py
+++ b/database_client/database_client.py
@@ -417,7 +417,7 @@ class DatabaseClient:
             data_sources.approval_status as approval_status
         FROM
             data_sources
-        FULL JOIN
+        INNER JOIN
             data_sources_archive_info
         ON
             data_sources.airtable_uid = data_sources_archive_info.airtable_uid

--- a/database_client/database_client.py
+++ b/database_client/database_client.py
@@ -409,12 +409,10 @@ class DatabaseClient:
         sql_query = """
         SELECT
             data_sources.airtable_uid,
-            data_sources.source_url as source_url,
-            data_sources_archive_info.update_frequency as update_frequency,
-            data_sources_archive_info.last_cached as last_cached,
-            data_sources.broken_source_url_as_of as broken_source_url_as_of
-            data_sources.url_status as url_status
-            data_sources.approval_status as approval_status
+            source_url,
+            update_frequency,
+            last_cached,
+            broken_source_url_as_of
         FROM
             data_sources
         INNER JOIN

--- a/database_client/database_client.py
+++ b/database_client/database_client.py
@@ -399,7 +399,8 @@ class DatabaseClient:
         Pulls data sources to be archived by the automatic archives script.
 
         A data source is selected for archival if:
-        (the data source has not been archived previously OR the data source is updated regularly)
+        The data source has been approved
+        AND (the data source has not been archived previously OR the data source is updated regularly)
         AND the source url is not broken
         AND the source url is not null.
 
@@ -412,6 +413,8 @@ class DatabaseClient:
             data_sources_archive_info.update_frequency as update_frequency,
             data_sources_archive_info.last_cached as last_cached,
             data_sources.broken_source_url_as_of as broken_source_url_as_of
+            data_sources.url_status as url_status
+            data_sources.approval_status as approval_status
         FROM
             data_sources
         FULL JOIN
@@ -419,7 +422,7 @@ class DatabaseClient:
         ON
             data_sources.airtable_uid = data_sources_archive_info.airtable_uid
         WHERE 
-            (last_cached IS NULL OR update_frequency IS NOT NULL) AND broken_source_url_as_of IS NULL AND url_status <> 'broken' AND source_url IS NOT NULL
+            approval_status = 'approved' AND (last_cached IS NULL OR update_frequency IS NOT NULL) AND broken_source_url_as_of IS NULL AND url_status <> 'broken' AND source_url IS NOT NULL
         """
         self.cursor.execute(sql_query)
         data_sources = self.cursor.fetchall()

--- a/database_client/dynamic_query_constructor.py
+++ b/database_client/dynamic_query_constructor.py
@@ -128,7 +128,7 @@ class DynamicQueryConstructor:
                 data_sources ON agency_source_link.airtable_uid = data_sources.airtable_uid
             INNER JOIN
                 agencies ON agency_source_link.agency_described_linked_uid = agencies.airtable_uid
-            FULL JOIN
+            INNER JOIN
                 data_sources_archive_info ON data_sources.airtable_uid = data_sources_archive_info.airtable_uid
             WHERE
                 data_sources.approval_status = 'approved' AND data_sources.airtable_uid = %s

--- a/database_client/dynamic_query_constructor.py
+++ b/database_client/dynamic_query_constructor.py
@@ -128,7 +128,7 @@ class DynamicQueryConstructor:
                 data_sources ON agency_source_link.airtable_uid = data_sources.airtable_uid
             INNER JOIN
                 agencies ON agency_source_link.agency_described_linked_uid = agencies.airtable_uid
-            INNER JOIN
+            FULL JOIN
                 data_sources_archive_info ON data_sources.airtable_uid = data_sources_archive_info.airtable_uid
             WHERE
                 data_sources.approval_status = 'approved' AND data_sources.airtable_uid = %s

--- a/database_client/dynamic_query_constructor.py
+++ b/database_client/dynamic_query_constructor.py
@@ -8,6 +8,7 @@ from psycopg2 import sql
 from database_client.constants import (
     AGENCY_APPROVED_COLUMNS,
     DATA_SOURCES_APPROVED_COLUMNS,
+    ARCHIVE_INFO_APPROVED_COLUMNS,
     RESTRICTED_DATA_SOURCE_COLUMNS,
     RESTRICTED_COLUMNS,
 )
@@ -65,9 +66,12 @@ class DynamicQueryConstructor:
         data_sources_columns = DynamicQueryConstructor.create_table_columns(
             table="data_sources", columns=DATA_SOURCES_APPROVED_COLUMNS
         )
+        archive_info_columns = DynamicQueryConstructor.create_table_columns(
+            table="data_sources_archive_info", columns=ARCHIVE_INFO_APPROVED_COLUMNS
+        )
 
         fields = DynamicQueryConstructor.build_fields(
-            columns_only=data_sources_columns,
+            columns_only=data_sources_columns + archive_info_columns,
             columns_and_alias=[
                 TableColumnAlias(table="agencies", column="name", alias="agency_name")
             ],
@@ -82,6 +86,8 @@ class DynamicQueryConstructor:
                 data_sources ON agency_source_link.airtable_uid = data_sources.airtable_uid
             INNER JOIN
                 agencies ON agency_source_link.agency_described_linked_uid = agencies.airtable_uid
+            INNER JOIN
+                data_sources_archive_info ON data_sources.airtable_uid = data_sources_archive_info.airtable_uid
             WHERE
                 data_sources.approval_status = 'approved'
         """
@@ -135,6 +141,9 @@ class DynamicQueryConstructor:
         data_sources_columns = DynamicQueryConstructor.create_table_columns(
             table="data_sources", columns=DATA_SOURCES_APPROVED_COLUMNS
         )
+        archive_info_columns = DynamicQueryConstructor.create_table_columns(
+            table="data_sources_archive_info", columns=ARCHIVE_INFO_APPROVED_COLUMNS
+        )
         fields = DynamicQueryConstructor.build_fields(
             columns_only=data_sources_columns,
         )
@@ -144,6 +153,8 @@ class DynamicQueryConstructor:
                 {fields}
             FROM
                 data_sources
+            INNER JOIN
+                data_sources_archive_info ON data_sources.airtable_uid = data_sources_archive_info.airtable_uid
             WHERE
                 approval_status = 'needs identification'
         """
@@ -154,7 +165,7 @@ class DynamicQueryConstructor:
     def zip_needs_identification_data_source_results(
         results: list[tuple],
     ) -> list[dict]:
-        return [dict(zip(DATA_SOURCES_APPROVED_COLUMNS, result)) for result in results]
+        return [dict(zip(DATA_SOURCES_APPROVED_COLUMNS + ARCHIVE_INFO_APPROVED_COLUMNS, result)) for result in results]
 
     @staticmethod
     def create_data_source_update_query(

--- a/database_client/dynamic_query_constructor.py
+++ b/database_client/dynamic_query_constructor.py
@@ -96,6 +96,9 @@ class DynamicQueryConstructor:
         agencies_approved_columns = DynamicQueryConstructor.create_table_columns(
             table="agencies", columns=AGENCY_APPROVED_COLUMNS
         )
+        archive_info_columns = DynamicQueryConstructor.create_table_columns(
+            table="data_sources_archive_info", columns=ARCHIVE_INFO_APPROVED_COLUMNS
+        )
         alias_columns = [
             TableColumnAlias(table="agencies", column="name", alias="agency_name"),
             TableColumnAlias(
@@ -106,7 +109,7 @@ class DynamicQueryConstructor:
             ),
         ]
         fields = DynamicQueryConstructor.build_fields(
-            columns_only=data_sources_columns + agencies_approved_columns,
+            columns_only=data_sources_columns + agencies_approved_columns + archive_info_columns,
             columns_and_alias=alias_columns,
         )
         sql_query = sql.SQL(
@@ -119,6 +122,8 @@ class DynamicQueryConstructor:
                 data_sources ON agency_source_link.airtable_uid = data_sources.airtable_uid
             INNER JOIN
                 agencies ON agency_source_link.agency_described_linked_uid = agencies.airtable_uid
+            INNER JOIN
+                data_sources_archive_info ON data_sources.airtable_uid = data_sources_archive_info.airtable_uid
             WHERE
                 data_sources.approval_status = 'approved' AND data_sources.airtable_uid = %s
         """

--- a/database_client/result_formatter.py
+++ b/database_client/result_formatter.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from database_client.constants import (
     DATA_SOURCES_APPROVED_COLUMNS,
+    ARCHIVE_INFO_APPROVED_COLUMNS,
     DATA_SOURCES_MAP_COLUMN,
     DATA_SOURCES_OUTPUT_COLUMNS,
     AGENCY_APPROVED_COLUMNS,
@@ -42,7 +43,7 @@ class ResultFormatter:
         results: list[tuple],
     ) -> list[dict]:
         return ResultFormatter.convert_data_source_matches(
-            DATA_SOURCES_APPROVED_COLUMNS, results
+            DATA_SOURCES_APPROVED_COLUMNS + ARCHIVE_INFO_APPROVED_COLUMNS, results
         )
 
     @staticmethod
@@ -60,7 +61,7 @@ class ResultFormatter:
     @staticmethod
     def zip_get_data_source_by_id_results(results: tuple[Any, ...]) -> dict[str, Any]:
         data_source_and_agency_columns = (
-            DATA_SOURCES_APPROVED_COLUMNS + AGENCY_APPROVED_COLUMNS
+            DATA_SOURCES_APPROVED_COLUMNS + AGENCY_APPROVED_COLUMNS + ARCHIVE_INFO_APPROVED_COLUMNS
         )
         data_source_and_agency_columns.extend(
             ["data_source_id", "agency_id", "agency_name"]

--- a/middleware/archives_queries.py
+++ b/middleware/archives_queries.py
@@ -54,7 +54,7 @@ def update_archives_data(
     """
     if broken_as_of:
         db_client.update_url_status_to_broken(data_id, broken_as_of, last_cached)
-    else:
-        db_client.update_last_cached(data_id, last_cached)
+    
+    db_client.update_last_cached(data_id, last_cached)
 
     return make_response({"status": "success"}, HTTPStatus.OK)

--- a/resources/Archives.py
+++ b/resources/Archives.py
@@ -20,7 +20,7 @@ archives_get_model = namespace_archives.model(
     "ArchivesResponse",
     {
         "id": fields.String(description="The ID of the data source"),
-        "last_cached": fields.Date(description="The last date the data was cached"),
+        "last_cached": fields.DateTime(description="The last date the data was cached"),
         "source_url": fields.String(description="The URL of the data source"),
         "update_frequency": fields.String(description="The archive update frequency of the data source"),
     },
@@ -30,7 +30,7 @@ archives_post_model = namespace_archives.model(
     "ArchivesPost",
     {
         "id": fields.String(description="The ID of the data source", required=True),
-        "last_cached": fields.Date(description="The last date the data was cached"),
+        "last_cached": fields.DateTime(description="The last date the data was cached"),
         "broken_source_url_as_of": fields.Date(description="The date the source was marked as broken"),
     },
 )

--- a/tests/integration/test_archives.py
+++ b/tests/integration/test_archives.py
@@ -64,7 +64,9 @@ def test_archives_put(
     cursor = dev_db_connection.cursor()
     cursor.execute(
         """
-    SELECT last_cached, broken_source_url_as_of FROM data_sources where airtable_uid = %s
+    SELECT last_cached, broken_source_url_as_of 
+    FROM data_sources INNER JOIN data_sources_archive_info ON data_sources.airtable_uid = data_sources_archive_info.airtable_uid 
+    WHERE airtable_uid = %s
     """,
         (data_source_id,),
     )

--- a/tests/integration/test_archives.py
+++ b/tests/integration/test_archives.py
@@ -65,7 +65,8 @@ def test_archives_put(
     cursor.execute(
         """
     SELECT last_cached, broken_source_url_as_of 
-    FROM data_sources INNER JOIN data_sources_archive_info ON data_sources.airtable_uid = data_sources_archive_info.airtable_uid 
+    FROM data_sources 
+    INNER JOIN data_sources_archive_info ON data_sources.airtable_uid = data_sources_archive_info.airtable_uid 
     WHERE airtable_uid = %s
     """,
         (data_source_id,),

--- a/tests/integration/test_archives.py
+++ b/tests/integration/test_archives.py
@@ -67,7 +67,7 @@ def test_archives_put(
     SELECT last_cached, broken_source_url_as_of 
     FROM data_sources 
     INNER JOIN data_sources_archive_info ON data_sources.airtable_uid = data_sources_archive_info.airtable_uid 
-    WHERE airtable_uid = %s
+    WHERE data_sources.airtable_uid = %s
     """,
         (data_source_id,),
     )

--- a/tests/integration/test_archives.py
+++ b/tests/integration/test_archives.py
@@ -43,7 +43,7 @@ def test_archives_put(
     user_info = create_test_user_api(client_with_db)
     api_key = create_api_key(client_with_db, user_info)
     data_source_id = insert_test_data_source(dev_db_connection.cursor())
-    last_cached = datetime.date(year=2020, month=3, day=4)
+    last_cached = datetime.datetime(year=2020, month=3, day=4)
     broken_as_of = datetime.date(year=1993, month=11, day=13)
     response = client_with_db.put(
         "/archives",

--- a/tests/test_database_client.py
+++ b/tests/test_database_client.py
@@ -212,7 +212,7 @@ def test_update_last_cached(live_database_client):
     # Add a new data source to the database
     insert_test_agencies_and_sources_if_not_exist(live_database_client.cursor)
     # Update the data source's last_cached value with the DatabaseClient method
-    new_last_cached = datetime.now()
+    new_last_cached = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
     live_database_client.update_last_cached("SOURCE_UID_1", new_last_cached)
 
     # Fetch the data source from the database to confirm the change

--- a/tests/test_database_client.py
+++ b/tests/test_database_client.py
@@ -219,7 +219,7 @@ def test_update_last_cached(live_database_client):
     result = live_database_client.get_data_source_by_id("SOURCE_UID_1")
     zipped_results = ResultFormatter.zip_get_data_source_by_id_results(result)
 
-    assert zipped_results["last_cached"] == new_last_cached.strftime("%Y-%m-%d")
+    assert zipped_results["last_cached"] == new_last_cached.strftime("%Y-%m-%d %H:%M:%S")
 
 
 def test_get_quick_search_results(live_database_client):

--- a/tests/test_database_client.py
+++ b/tests/test_database_client.py
@@ -219,7 +219,7 @@ def test_update_last_cached(live_database_client):
     result = live_database_client.get_data_source_by_id("SOURCE_UID_1")
     zipped_results = ResultFormatter.zip_get_data_source_by_id_results(result)
 
-    assert zipped_results["last_cached"] == new_last_cached.strftime("%Y-%m-%d %H:%M:%S")
+    assert zipped_results["last_cached"] == new_last_cached
 
 
 def test_get_quick_search_results(live_database_client):

--- a/utilities/common.py
+++ b/utilities/common.py
@@ -5,7 +5,9 @@ import json
 
 def convert_dates_to_strings(data_dict: dict) -> dict:
     for key, value in data_dict.items():
-        if isinstance(value, datetime.date):
+        if key == "last_cached" and value is not None:
+            data_dict[key] = value.strftime("%Y-%m-%d %H:%M:%S")
+        elif isinstance(value, datetime.date):
             data_dict[key] = value.strftime("%Y-%m-%d")
     return data_dict
 


### PR DESCRIPTION
#### This PR is dependent on https://github.com/Police-Data-Accessibility-Project/prod-to-dev-migration/pull/19 before being merged

#### Fixes

* Part of https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/309 and https://github.com/Police-Data-Accessibility-Project/automatic-archives/issues/21

#### Description

* This PR sets up the infrastructure for a new table called `data_sources_archive_info` that contains `update_frequency`, `last_cached` and a new column called `next_cache`
* The following database query will be used to setup the new table and transfer the data over: [query.txt](https://github.com/user-attachments/files/16339202/query.txt)

#### Testing

1. Run the query in a freshly wiped sandbox database
2. Checkout the branch locally and setup the v2 testing environment
3. Run `pytest` in the tests folder
4. Profit