### PR TITLE
Add test_get_role_by_api_key()

### DIFF
--- a/tests/test_database_client.py
+++ b/tests/test_database_client.py
@@ -373,6 +373,25 @@ def test_get_role_by_email(live_database_client):
     assert role_info.role == "test_role"
 
 
+def test_get_role_by_api_key(live_database_client):
+    # Add a new user to the database
+    live_database_client.add_new_user(
+        email="test_user",
+        password_digest="test_password",
+    )
+
+    # Add a role to the user
+    live_database_client.cursor.execute(
+        "update users set role = 'test_role', api_key = 'test_api_key' where email = 'test_user'",
+    )
+
+    # Fetch the user using its email with the DatabaseClient method
+    role_info = live_database_client.get_role_by_api_key(api_key="test_api_key")
+
+    # Confirm the role is retrieved successfully
+    assert role_info.role == "test_role"
+
+
 def test_add_new_session_token(live_database_client):
     # Add a new user to the database
     email = uuid.uuid4().hex

--- a/tests/test_database_client.py
+++ b/tests/test_database_client.py
@@ -380,12 +380,12 @@ def test_get_role_by_api_key(live_database_client):
         password_digest="test_password",
     )
 
-    # Add a role to the user
+    # Add a role and api_key to the user
     live_database_client.cursor.execute(
         "update users set role = 'test_role', api_key = 'test_api_key' where email = 'test_user'",
     )
 
-    # Fetch the user using its email with the DatabaseClient method
+    # Fetch the user's role using its api key with the DatabaseClient method
     role_info = live_database_client.get_role_by_api_key(api_key="test_api_key")
 
     # Confirm the role is retrieved successfully


### PR DESCRIPTION
#### Description

* While working on https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/303 I noticed there was no existing test method for `get_role_by_api_key()` in `database_client.py` so figured I'd add one real quick
* The logic is based off of `test_get_role_by_email()` with a few minor changes

#### Testing

1. Checkout the branch
2. Setup testing environment like normal
3. Run `pytest test_database_client.py` and confirm all tests pass