### PR TITLE
Create column permission logic and associated tests

### DIFF
--- a/database_client/enums.py
+++ b/database_client/enums.py
@@ -1,5 +1,22 @@
 from enum import Enum
 
+class RelationRoleEnum(Enum):
+    """
+    Correlates to the relation_role enum in the database
+    """
+    OWNER = "OWNER"
+    STANDARD = "STANDARD"
+    ADMIN = "ADMIN"
+
+class ColumnPermissionEnum(Enum):
+    """
+    Correlates to the access_permission enum in the database
+    """
+    READ = "READ"
+    WRITE = "WRITE"
+    NONE = "NONE"
+
+
 class ExternalAccountTypeEnum(Enum):
     GITHUB = "github"
 

--- a/middleware/column_permission_logic.py
+++ b/middleware/column_permission_logic.py
@@ -1,0 +1,56 @@
+from enum import Enum
+from http import HTTPStatus
+
+from flask_restx import abort
+
+from database_client.database_client import DatabaseClient
+from database_client.enums import RelationRoleEnum, ColumnPermissionEnum
+
+
+def get_permitted_columns(
+    db_client: DatabaseClient,
+    relation: str,
+    role: RelationRoleEnum,
+    column_permission: ColumnPermissionEnum
+) -> list[str]:
+    return db_client.get_permitted_columns(
+        relation=relation,
+        role=role,
+        column_permission=column_permission
+    )
+
+def check_has_permission_to_edit_columns(
+    db_client: DatabaseClient,
+    relation: str,
+    role: RelationRoleEnum,
+    columns: list[str]
+):
+    """
+    Checks if the user has permission to edit the given columns
+    :param db_client:
+    :param relation:
+    :param role:
+    :param columns:
+    :return:
+    """
+    writeable_columns = get_permitted_columns(
+        db_client=db_client,
+        relation=relation,
+        role=role,
+        column_permission=ColumnPermissionEnum.WRITE
+    )
+    invalid_columns = []
+    for column in columns:
+        if column not in writeable_columns:
+            invalid_columns.append(column)
+
+    if len(invalid_columns) == 0:
+        return
+
+    abort(
+        code=HTTPStatus.FORBIDDEN,
+        message=f"""
+        You do not have permission to edit the following columns: 
+        {invalid_columns}
+        """,
+    )

--- a/tests/middleware/test_column_permission_logic.py
+++ b/tests/middleware/test_column_permission_logic.py
@@ -1,0 +1,64 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from database_client.enums import ColumnPermissionEnum
+from middleware.column_permission_logic import (
+    get_permitted_columns,
+    check_has_permission_to_edit_columns,
+)
+
+
+def test_get_permitted_columns():
+    mock = MagicMock()
+
+    get_permitted_columns(
+        db_client=mock.db_client,
+        relation=mock.relation,
+        role=mock.role,
+        column_permission=mock.column_permission,
+    )
+
+    mock.db_client.get_permitted_columns.assert_called_once_with(
+        relation=mock.relation, role=mock.role, column_permission=mock.column_permission
+    )
+
+@pytest.fixture
+def mock_abort(monkeypatch):
+    mock = MagicMock()
+    monkeypatch.setattr("middleware.column_permission_logic.abort", mock)
+    return mock
+
+def test_check_has_permission_to_edit_columns_success(mock_abort):
+    mock = MagicMock()
+    mock.db_client.get_permitted_columns.return_value = ["column_a", "column_b"]
+
+    check_has_permission_to_edit_columns(
+        db_client=mock.db_client,
+        relation=mock.relation,
+        role=mock.role,
+        columns=["column_a", "column_b"],
+    )
+
+    mock_abort.assert_not_called()
+
+    mock.db_client.get_permitted_columns.assert_called_once_with(
+        relation=mock.relation, role=mock.role, column_permission=ColumnPermissionEnum.WRITE
+    )
+
+def test_check_has_permission_to_edit_columns_fail(mock_abort):
+    mock = MagicMock()
+    mock.db_client.get_permitted_columns.return_value = ["column_a"]
+
+    check_has_permission_to_edit_columns(
+        db_client=mock.db_client,
+        relation=mock.relation,
+        role=mock.role,
+        columns=["column_a", "column_b"],
+    )
+
+    mock.db_client.get_permitted_columns.assert_called_once_with(
+        relation=mock.relation, role=mock.role, column_permission=ColumnPermissionEnum.WRITE
+    )
+
+    mock_abort.assert_called_once()


### PR DESCRIPTION
#### Fixes

* Backend component of https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/391

#### Description

* Adds logic for determining column permissions for a given role and level of access based off of configuration data uploaded to the database

#### Testing

* Run all tests in `tests` directory, confirm functionality. 

#### Performance

* Additional test overhead
* Permission logic will add overhead in any new endpoint.

#### Docs

* Not applicable. 

#### Breaking Changes

* Not applicable.