### PR TITLE
Create DatabaseClient._update_entry_in_table() method

### DIFF
--- a/configuration_files/column_permissions/test_table.csv
+++ b/configuration_files/column_permissions/test_table.csv
@@ -1,5 +1,0 @@
-COLUMN,STANDARD,ADMIN
-standard_view_admin_view,VIEW,VIEW
-standard_view_admin_edit,VIEW,EDIT
-standard_none_admin_view,,VIEW
-standard_none_admin_edit,,EDIT

--- a/database_client/dynamic_query_constructor.py
+++ b/database_client/dynamic_query_constructor.py
@@ -115,7 +115,9 @@ class DynamicQueryConstructor:
             ),
         ]
         fields = DynamicQueryConstructor.build_fields(
-            columns_only=data_sources_columns + agencies_approved_columns + archive_info_columns,
+            columns_only=data_sources_columns
+            + agencies_approved_columns
+            + archive_info_columns,
             columns_and_alias=alias_columns,
         )
         sql_query = sql.SQL(
@@ -165,40 +167,15 @@ class DynamicQueryConstructor:
     def zip_needs_identification_data_source_results(
         results: list[tuple],
     ) -> list[dict]:
-        return [dict(zip(DATA_SOURCES_APPROVED_COLUMNS + ARCHIVE_INFO_APPROVED_COLUMNS, result)) for result in results]
-
-    @staticmethod
-    def create_data_source_update_query(
-        data: dict, data_source_id: str
-    ) -> sql.Composed:
-        """
-        Creates a query to update a data source in the database.
-
-        :param data: A dictionary containing the updated data source details.
-        :param data_source_id: The ID of the data source to be updated.
-        """
-        data_to_update = []
-        for key, value in data.items():
-            if key in RESTRICTED_DATA_SOURCE_COLUMNS:
-                continue
-            data_to_update.append(
-                sql.SQL("{} = {}").format(sql.Identifier(key), sql.Literal(value))
+        return [
+            dict(
+                zip(
+                    DATA_SOURCES_APPROVED_COLUMNS + ARCHIVE_INFO_APPROVED_COLUMNS,
+                    result,
+                )
             )
-
-        data_to_update_sql = sql.SQL(", ").join(data_to_update)
-
-        query = sql.SQL(
-            """
-            UPDATE data_sources 
-            SET {data_to_update}
-            WHERE airtable_uid = {data_source_id}
-        """
-        ).format(
-            data_to_update=data_to_update_sql,
-            data_source_id=sql.Literal(data_source_id),
-        )
-
-        return query
+            for result in results
+        ]
 
     @staticmethod
     def create_new_data_source_query(data: dict) -> sql.Composed:
@@ -239,7 +216,6 @@ class DynamicQueryConstructor:
         )
 
         return query
-
 
     @staticmethod
     def generate_new_typeahead_suggestion_query(search_term: str):
@@ -289,10 +265,11 @@ class DynamicQueryConstructor:
         state: str,
         record_categories: Optional[list[RecordCategories]] = None,
         county: Optional[str] = None,
-        locality: Optional[str] = None
-    ) ->sql.Composed:
+        locality: Optional[str] = None,
+    ) -> sql.Composed:
 
-        base_query = sql.SQL("""
+        base_query = sql.SQL(
+            """
             SELECT
                 data_sources.airtable_uid,
                 data_sources.name AS data_source_name,
@@ -316,44 +293,100 @@ class DynamicQueryConstructor:
                 state_names ON agencies.state_iso = state_names.state_iso
             INNER JOIN
                 counties ON agencies.county_fips = counties.fips
-        """)
+        """
+        )
 
         join_conditions = []
         where_conditions = [
-            sql.SQL("LOWER(state_names.state_name) = LOWER({state_name})").format(state_name=sql.Literal(state)),
+            sql.SQL("LOWER(state_names.state_name) = LOWER({state_name})").format(
+                state_name=sql.Literal(state)
+            ),
             sql.SQL("data_sources.approval_status = 'approved'"),
-            sql.SQL("data_sources.url_status NOT IN ('broken', 'none found')")
+            sql.SQL("data_sources.url_status NOT IN ('broken', 'none found')"),
         ]
 
         if record_categories is not None:
-            join_conditions.append(sql.SQL("""
+            join_conditions.append(
+                sql.SQL(
+                    """
                 INNER JOIN
                     record_types ON data_sources.record_type_id = record_types.id
                 INNER JOIN
                     record_categories ON record_types.category_id = record_categories.id
-            """))
+            """
+                )
+            )
 
-            record_type_str_tup = tuple([record_type.value for record_type in record_categories])
-            where_conditions.append(sql.SQL(
-                "record_categories.name in {record_types}"
-            ).format(record_types=sql.Literal(record_type_str_tup)))
+            record_type_str_tup = tuple(
+                [record_type.value for record_type in record_categories]
+            )
+            where_conditions.append(
+                sql.SQL("record_categories.name in {record_types}").format(
+                    record_types=sql.Literal(record_type_str_tup)
+                )
+            )
 
         if county is not None:
-            where_conditions.append(sql.SQL(
-                "LOWER(counties.name) = LOWER({county_name})"
-            ).format(county_name=sql.Literal(county)))
+            where_conditions.append(
+                sql.SQL("LOWER(counties.name) = LOWER({county_name})").format(
+                    county_name=sql.Literal(county)
+                )
+            )
 
         if locality is not None:
-            where_conditions.append(sql.SQL(
-                "LOWER(agencies.municipality) = LOWER({locality})"
-            ).format(locality=sql.Literal(locality)))
+            where_conditions.append(
+                sql.SQL("LOWER(agencies.municipality) = LOWER({locality})").format(
+                    locality=sql.Literal(locality)
+                )
+            )
 
-        query = sql.Composed([
-            base_query,
-            sql.SQL(' ').join(join_conditions),
-            sql.SQL(" WHERE "),
-            sql.SQL(' AND ').join(where_conditions)
-        ])
+        query = sql.Composed(
+            [
+                base_query,
+                sql.SQL(" ").join(join_conditions),
+                sql.SQL(" WHERE "),
+                sql.SQL(" AND ").join(where_conditions),
+            ]
+        )
 
         return query
 
+    @staticmethod
+    def create_update_query(
+        table_name: str,
+        id_value: int,
+        column_edit_mappings: dict[str, str],
+        id_column_name: str
+    ) -> sql.Composed:
+        """
+        Dynamically constructs an update query based on the provided mappings
+        :param table_name: Name of the table to update
+        :param id_value: The ID of the entry to update
+        :param column_edit_mappings: A dictionary mapping column names to their new values
+        :return: A composed SQL query ready for execution
+        """
+
+        # Start with the base update query
+        base_query = sql.SQL("UPDATE {table} SET ").format(
+            table=sql.Identifier(table_name)
+        )
+
+        # Generate the column assignments
+        assignments = [
+            sql.SQL("{column} = {value}").format(
+                column=sql.Identifier(column_name),
+                value=sql.Literal(column_value)
+            )
+            for column_name, column_value in column_edit_mappings.items()
+        ]
+
+        # Combine the base query with the assignments
+        query = base_query + sql.SQL(", ").join(assignments)
+
+        # Add the WHERE clause to specify the entry to update
+        query += sql.SQL(" WHERE {id_column} = {id_value}").format(
+            id_column=sql.Identifier(id_column_name),
+            id_value=sql.Literal(id_value)
+        )
+
+        return query

--- a/middleware/archives_queries.py
+++ b/middleware/archives_queries.py
@@ -60,7 +60,7 @@ def update_archives_data(
     :return: A dictionary containing a message about the update operation
     """
     if broken_as_of:
-        db_client.update_url_status_to_broken(data_id, broken_as_of, last_cached)
+        db_client.update_url_status_to_broken(data_id, broken_as_of)
     
     db_client.update_last_cached(data_id, last_cached)
 

--- a/tests/middleware/test_archives_queries.py
+++ b/tests/middleware/test_archives_queries.py
@@ -9,27 +9,16 @@ from middleware.archives_queries import (
 from tests.helper_scripts.DynamicMagicMock import DynamicMagicMock
 
 
-class UpdateArchivesDataMocks(DynamicMagicMock):
-    db_client: MagicMock
-    data_id: MagicMock
-    last_cached: MagicMock
-    broken_as_of: MagicMock
-    archives_put_broken_as_of_results: MagicMock
-    archives_put_last_cached_results: MagicMock
-    make_response: MagicMock
-
 
 @pytest.fixture
-def setup_update_archives_data_mocks(monkeypatch):
-    mock = UpdateArchivesDataMocks(
-        patch_root="middleware.archives_queries",
-        mocks_to_patch=["make_response"],
-    )
+def make_response_mock(monkeypatch):
+    mock = MagicMock()
+    monkeypatch.setattr("middleware.archives_queries.make_response", mock)
     return mock
 
 
-def test_update_archives_data_broken_as_of(setup_update_archives_data_mocks):
-    mock = setup_update_archives_data_mocks
+def test_update_archives_data_broken_as_of(make_response_mock):
+    mock = MagicMock()
 
     # Call function
     update_archives_data(
@@ -37,14 +26,14 @@ def test_update_archives_data_broken_as_of(setup_update_archives_data_mocks):
     )
 
     mock.db_client.update_url_status_to_broken.assert_called_with(
-        mock.data_id, mock.broken_as_of, mock.last_cached
+        mock.data_id, mock.broken_as_of
     )
-    mock.archives_put_last_cached_results.assert_not_called()
-    mock.make_response.assert_called_with({"status": "success"}, HTTPStatus.OK)
+    mock.db_client.update_last_cached.assert_called_with(mock.data_id, mock.last_cached)
+    make_response_mock.assert_called_with({"status": "success"}, HTTPStatus.OK)
 
 
-def test_update_archives_data_not_broken_as_of(setup_update_archives_data_mocks):
-    mock = setup_update_archives_data_mocks
+def test_update_archives_data_not_broken_as_of(make_response_mock):
+    mock = MagicMock()
 
     # Call function
     update_archives_data(mock.db_client, mock.data_id, mock.last_cached, None)
@@ -52,4 +41,4 @@ def test_update_archives_data_not_broken_as_of(setup_update_archives_data_mocks)
     mock.db_client.update_url_status_to_broken.assert_not_called()
     mock.db_client.update_last_cached.assert_called_with(mock.data_id, mock.last_cached)
 
-    mock.make_response.assert_called_with({"status": "success"}, HTTPStatus.OK)
+    make_response_mock.assert_called_with({"status": "success"}, HTTPStatus.OK)


### PR DESCRIPTION
#### Fixes

* https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/398

#### Description

* Create DatabaseClient._update_entry_in_table() method, which dynamically updates a single entry in a given table given certain parameters
* Updated a number of database client methods which were previously using bespoke update scripts to instead call this.
* Tests relevant to this were not updated, as it simply replaced internal logic with a helper function
* Leave It Better Than You Found It (LIBTYFI): Removed `last_cached` parameter as argument from update_url_status_to_broken and update tests accordingly.

#### Testing

* Run tests in `tests` directory and confirm functionality.

#### Performance

* Marginal additional overhead due to calling a helper function, rather than calling the dynamic query generation directly

#### Docs

* Not applicable.

#### Breaking Changes

* Not applicable.