### PR TITLE
Update Search endpoint logic to break down results by jurisdiction type

### DIFF
--- a/database_client/database_client.py
+++ b/database_client/database_client.py
@@ -680,7 +680,7 @@ class DatabaseClient:
         record_categories: Optional[list[RecordCategories]] = None,
         county: Optional[str] = None,
         locality: Optional[str] = None,
-    ) -> List[QuickSearchResult]:
+    ) -> List[dict]:
         """
         Searches for data sources in the database.
 
@@ -697,24 +697,7 @@ class DatabaseClient:
             locality=locality,
         )
         self.cursor.execute(query)
-        results = self.cursor.fetchall()
-        return [
-            self.QuickSearchResult(
-                id=row["airtable_uid"],
-                data_source_name=row["data_source_name"],
-                description=row["description"],
-                record_type=row["record_type"],
-                url=row["source_url"],
-                format=row["record_format"],
-                coverage_start=row["coverage_start"],
-                coverage_end=row["coverage_end"],
-                agency_supplied=row["agency_supplied"],
-                agency_name=row["agency_name"],
-                municipality=row["municipality"],
-                state=row["state_iso"],
-            )
-            for row in results
-        ]
+        return self.cursor.fetchall()
 
     def link_external_account(
         self,

--- a/middleware/constants.py
+++ b/middleware/constants.py
@@ -1,0 +1,2 @@
+
+data_key = "data"

--- a/middleware/data_requests.py
+++ b/middleware/data_requests.py
@@ -10,7 +10,7 @@ from middleware.access_logic import AccessInfo, get_access_info_from_jwt
 from middleware.column_permission_logic import get_permitted_columns, check_has_permission_to_edit_columns
 from middleware.dataclasses import EntryDataRequest
 from middleware.enums import AccessTypeEnum, PermissionsEnum, Relations
-from middleware.util import message_response
+from middleware.util import message_response, format_list_response
 
 RELATION = Relations.DATA_REQUESTS.value
 
@@ -96,12 +96,10 @@ def get_data_requests_wrapper(
         access_info=access_info
     )
     formatted_data_requests = get_formatted_data_requests(access_info, db_client, relation_role)
+    formatted_list_response = format_list_response(formatted_data_requests)
 
     return make_response(
-        {
-            "count": len(formatted_data_requests),
-            "data_requests": formatted_data_requests,
-        },
+        formatted_list_response,
         HTTPStatus.OK,
     )
 

--- a/middleware/enums.py
+++ b/middleware/enums.py
@@ -43,3 +43,12 @@ class Relations(Enum):
     A list of valid relations for the database
     """
     DATA_REQUESTS = "data_requests"
+
+class Jurisdiction(Enum):
+    """
+    A list of valid agency jurisdictions for the database
+    """
+    FEDERAL = "federal"
+    STATE = "state"
+    COUNTY = "county"
+    LOCALITY = "locality"

--- a/middleware/util.py
+++ b/middleware/util.py
@@ -4,6 +4,8 @@ from http import HTTPStatus
 from dotenv import dotenv_values, find_dotenv
 from flask import Response, make_response
 
+from middleware.constants import data_key
+
 
 def get_env_variable(name: str) -> str:
     """
@@ -30,7 +32,7 @@ def format_list_response(data: list) -> dict:
     Returns:
         dict: A dictionary with the count and data keys.
     """
-    return {"count": len(data), "data": data}
+    return {"count": len(data), data_key: data}
 
 def message_response(message: str, status_code: HTTPStatus) -> Response:
     return make_response(

--- a/tests/integration/test_data_requests.py
+++ b/tests/integration/test_data_requests.py
@@ -4,6 +4,7 @@ from http import HTTPStatus
 
 import pytest
 
+from middleware.constants import data_key
 from middleware.enums import PermissionsEnum
 from tests.fixtures import (
     connection_with_test_data,
@@ -54,15 +55,15 @@ def test_data_requests_get(ts: TestSetup):
         endpoint=GENERAL_ENDPOINT,
         headers=ts.tus.jwt_authorization_header,
     )
-    assert len(json_data["data_requests"]) > 0
-    assert isinstance(json_data["data_requests"], list)
-    assert isinstance(json_data["data_requests"][0], dict)
+    assert len(json_data[data_key]) > 0
+    assert isinstance(json_data[data_key], list)
+    assert isinstance(json_data[data_key][0], dict)
 
     # Check that first result is user's data request
-    assert json_data["data_requests"][0]["id"] == data_request_id_creator
+    assert json_data[data_key][0]["id"] == data_request_id_creator
 
     # Check that last result is not user's data request
-    assert json_data["data_requests"][-1]["id"] != data_request_id_creator
+    assert json_data[data_key][-1]["id"] != data_request_id_creator
 
     # Give user admin permission
     ts.db_client.add_user_permission(
@@ -78,7 +79,7 @@ def test_data_requests_get(ts: TestSetup):
     )
 
     # Assert admin columns are greater than user columns
-    assert len(admin_json_data["data_requests"][0]) > len(json_data["data_requests"][0])
+    assert len(admin_json_data[data_key][0]) > len(json_data[data_key][0])
 
 
 def create_data_request(dev_db_client, submission_notes, user_id = None):

--- a/tests/integration/test_search.py
+++ b/tests/integration/test_search.py
@@ -20,18 +20,34 @@ def test_search_get(flask_client_with_db, bypass_api_key_required):
         headers=tus.api_authorization_header,
     )
 
+    jurisdictions = ["federal", "state", "county", "locality"]
+
+    assert list(data.keys()) == ["count", "data"]
+    assert list(data["data"].keys()).sort() == jurisdictions.sort()
     assert data["count"] > 0
-    assert list(data["data"][0].keys()) == [
-        "agency_name",
-        "agency_supplied",
-        "coverage_end",
-        "coverage_start",
-        "data_source_name",
-        "description",
-        "format",
-        "id",
-        "municipality",
-        "record_type",
-        "state",
-        "url",
-    ]
+
+    jurisdiction_count = 0
+    for jurisdiction in jurisdictions:
+        assert list(data["data"][jurisdiction].keys()) == ["count", "results"]
+        jurisdiction_count += data["data"][jurisdiction]["count"]
+        if data["data"][jurisdiction]["count"] > 0:
+            assert (
+                list(data["data"][jurisdiction]["results"][0].keys()).sort()
+                == [
+                    "agency_name",
+                    "agency_supplied",
+                    "coverage_end",
+                    "coverage_start",
+                    "data_source_name",
+                    "description",
+                    "jurisdiction_type",
+                    "record_format",
+                    "id",
+                    "municipality",
+                    "record_type",
+                    "state",
+                    "url",
+                ].sort()
+            )
+
+    assert jurisdiction_count == data["count"]

--- a/tests/middleware/test_data_requests.py
+++ b/tests/middleware/test_data_requests.py
@@ -117,9 +117,11 @@ def test_get_data_requestor_with_creator_user_id():
     result = mock.db_client.create_data_request.return_value
 
 
+@patch(PATCH_ROOT + ".format_list_response")
 @patch(PATCH_ROOT + ".get_formatted_data_requests")
 def test_get_data_requests_wrapper(
     mock_get_formatted_data_requests: MagicMock,
+    mock_format_list_response: MagicMock,
     mock_get_data_requests_relation_role,
     mock_make_response,
     monkeypatch,
@@ -135,11 +137,13 @@ def test_get_data_requests_wrapper(
         mock.db_client,
         mock_get_data_requests_relation_role.return_value,
     )
+
+    mock_format_list_response.assert_called_once_with(
+        mock_get_formatted_data_requests.return_value
+    )
+
     mock_make_response.assert_called_once_with(
-        {
-            "count": 0,
-            "data_requests": mock_get_formatted_data_requests.return_value,
-        },
+        mock_format_list_response.return_value,
         HTTPStatus.OK,
     )
 

--- a/tests/middleware/test_search_logic.py
+++ b/tests/middleware/test_search_logic.py
@@ -1,13 +1,13 @@
 from http import HTTPStatus
 from unittest.mock import MagicMock
 
-from middleware.search_logic import search_wrapper
+from middleware.search_logic import search_wrapper, format_search_results
 from tests.helper_scripts.DynamicMagicMock import DynamicMagicMock
 
 
 class SearchWrapperMocks(DynamicMagicMock):
     make_response: MagicMock
-    dictify_namedtuple: MagicMock
+    format_search_results: MagicMock
 
 
 def test_search_wrapper(monkeypatch):
@@ -18,8 +18,6 @@ def test_search_wrapper(monkeypatch):
         mock.search_results
     )
 
-    mock.dictify_namedtuple.return_value = [MagicMock()]
-
     search_wrapper(mock.db_client, mock.dto)
     mock.db_client.search_with_location_and_record_type.assert_called_with(
         state=mock.dto.state,
@@ -27,7 +25,80 @@ def test_search_wrapper(monkeypatch):
         county=mock.dto.county,
         locality=mock.dto.locality,
     )
-    mock.dictify_namedtuple.assert_called_with(mock.search_results)
+    mock.format_search_results.assert_called_with(mock.search_results)
     mock.make_response.assert_called_with(
-        {"count": 1, "data": mock.dictify_namedtuple.return_value}, HTTPStatus.OK
+        mock.format_search_results.return_value, HTTPStatus.OK
     )
+
+
+def test_format_search_results():
+    search_results = [
+        {
+            "name": "test federal",
+            "jurisdiction_type": "federal",
+        },
+        {
+            "name": "test state",
+            "jurisdiction_type": "state",
+        },
+        {
+            "name": "test county",
+            "jurisdiction_type": "county",
+        },
+        {
+            "name": "test locality",
+            "jurisdiction_type": "locality",
+        },
+        {
+            "name": "another test locality",
+            "jurisdiction_type": "locality",
+        },
+    ]
+
+    expected_formatted_search_results = {
+        "count": 5,
+        "data": {
+            "federal": {
+                "count": 1,
+                "results": [
+                    {
+                        "name": "test federal",
+                        "jurisdiction_type": "federal",
+                    }
+                ],
+            },
+            "state": {
+                "count": 1,
+                "results": [
+                    {
+                        "name": "test state",
+                        "jurisdiction_type": "state",
+                    }
+                ],
+            },
+            "county": {
+                "count": 1,
+                "results": [
+                    {
+                        "name": "test county",
+                        "jurisdiction_type": "county",
+                    }
+                ],
+            },
+            "locality": {
+                "count": 2,
+                "results": [
+                    {
+                        "name": "test locality",
+                        "jurisdiction_type": "locality",
+                    },
+                    {
+                        "name": "another test locality",
+                        "jurisdiction_type": "locality",
+                    },
+                ],
+            },
+        },
+    }
+
+    assert format_search_results(search_results) == expected_formatted_search_results


### PR DESCRIPTION

### Fixes

* Backend portion of https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/409

### Description

* Update Search endpoint logic to break down results by jurisdiction type.

LIBTYFI:
* Refactored `DatabaseClient.create_search_query` to utilize `build_full_where_clause` function
* Refactored `get_data_requests_wrapper` to use `format_list_response` function rather than duplicate code

### Testing

* Run tests in `tests` directory
* Confirm api results as described in Swagger documentation conform to responses in API

### Performance

* Slight increase in middleware overhead as data must now be sorted into different sections by jurisdiction when formatting response.

### Docs

* Swagger API docs updated. 

### Breaking Changes

* Search endpoint response formatting has changed as a result of this. 