### PR TITLE
Address reset password functionality not working properly. Update tests.

### DIFF
--- a/middleware/primary_resource_logic/reset_token_queries.py
+++ b/middleware/primary_resource_logic/reset_token_queries.py
@@ -8,6 +8,7 @@ from marshmallow import Schema, fields
 from werkzeug.security import generate_password_hash
 
 from database_client.database_client import DatabaseClient
+from middleware.flask_response_manager import FlaskResponseManager
 from middleware.primary_resource_logic.login_queries import generate_api_key
 from middleware.primary_resource_logic.user_queries import user_check_email
 from middleware.webhook_logic import send_password_reset_link
@@ -36,6 +37,29 @@ class RequestResetPasswordRequestSchema(Schema):
         source=SourceMappingEnum.JSON,
     )
 
+class ResetPasswordSchema(Schema):
+    email = fields.Str(
+        required=True,
+        description="The email of the user",
+        source=SourceMappingEnum.JSON,
+    )
+    password = fields.Str(
+        required=True,
+        description="The new password of the user",
+        source=SourceMappingEnum.JSON,
+    )
+    token = fields.Str(
+        required=True,
+        description="The user's reset password token",
+        source=SourceMappingEnum.JSON,
+    )
+
+@dataclass
+class ResetPasswordDTO:
+    email: str
+    password: str
+    token: str
+
 
 def request_reset_password(db_client: DatabaseClient, email) -> Response:
     """
@@ -58,7 +82,7 @@ def request_reset_password(db_client: DatabaseClient, email) -> Response:
 
 
 def reset_password(
-    db_client: DatabaseClient, dto: RequestResetPasswordRequest
+    db_client: DatabaseClient, dto: ResetPasswordDTO
 ) -> Response:
     """
     Resets a user's password if the provided token is valid and not expired.
@@ -68,11 +92,25 @@ def reset_password(
     :return:
     """
     try:
-        email = validate_token(db_client, dto.token)
+        token_email = validate_token(db_client, dto.token)
     except InvalidTokenError:
         return invalid_token_response()
-    set_user_password(db_client, email, dto.token)
-    return make_response({"message": "Successfully updated password"}, HTTPStatus.OK)
+    validate_emails_match(dto.email, token_email)
+
+    set_user_password(
+        db_client=db_client,
+        email=token_email,
+        password=dto.password
+    )
+    return FlaskResponseManager.make_response({"message": "Successfully updated password"}, HTTPStatus.OK)
+
+
+def validate_emails_match(request_email: str, token_email: str):
+    if token_email != request_email:
+        FlaskResponseManager.abort(
+            code=HTTPStatus.BAD_REQUEST,
+            message="Invalid token."
+        )
 
 
 def set_user_password(db_client: DatabaseClient, email, password):

--- a/resources/ResetPassword.py
+++ b/resources/ResetPassword.py
@@ -4,12 +4,15 @@ from middleware.primary_resource_logic.reset_token_queries import (
     reset_password,
     RequestResetPasswordRequest,
     RequestResetPasswordRequestSchema,
+    ResetPasswordSchema,
+    ResetPasswordDTO,
 )
 from utilities.namespace import create_namespace
 
 from resources.PsycopgResource import PsycopgResource, handle_exceptions
 from middleware.schema_and_dto_logic.dynamic_schema_documentation_construction import (
-    get_restx_param_documentation, )
+    get_restx_param_documentation,
+)
 from middleware.schema_and_dto_logic.non_dto_dataclasses import SchemaPopulateParameters
 
 namespace_reset_password = create_namespace()
@@ -21,6 +24,7 @@ doc_info = get_restx_param_documentation(
 )
 
 reset_password_model = doc_info.model
+
 
 @namespace_reset_password.route("/reset-password")
 class ResetPassword(PsycopgResource):
@@ -47,7 +51,7 @@ class ResetPassword(PsycopgResource):
         return self.run_endpoint(
             wrapper_function=reset_password,
             schema_populate_parameters=SchemaPopulateParameters(
-                schema_class=RequestResetPasswordRequestSchema,
-                dto_class=RequestResetPasswordRequest,
-            )
+                schema_class=ResetPasswordSchema,
+                dto_class=ResetPasswordDTO,
+            ),
         )

--- a/tests/integration/test_reset_password.py
+++ b/tests/integration/test_reset_password.py
@@ -20,6 +20,14 @@ def test_reset_password_post(flask_client_with_db, dev_db_client, mocker):
     """
 
     user_info = create_test_user_api(flask_client_with_db)
+    # User should be able to log in with the old password
+    run_and_validate_request(
+        flask_client=flask_client_with_db,
+        http_method="post",
+        endpoint="/api/login",
+        json={"email": user_info.email, "password": user_info.password},
+    )
+
     old_password_digest = dev_db_client.get_user_info(user_info.email).password_digest
 
     token = request_reset_password_api(flask_client_with_db, mocker, user_info)
@@ -34,3 +42,57 @@ def test_reset_password_post(flask_client_with_db, dev_db_client, mocker):
     assert (
         new_password_digest != old_password_digest
     ), "Old and new password digests should be distinct"
+
+    # User should not be able to log in with the old password
+    run_and_validate_request(
+        flask_client=flask_client_with_db,
+        http_method="post",
+        endpoint="/api/login",
+        json={"email": user_info.email, "password": user_info.password},
+        expected_response_status=HTTPStatus.UNAUTHORIZED,
+    )
+
+    # User should be able to login with the new password
+    run_and_validate_request(
+        flask_client=flask_client_with_db,
+        http_method="post",
+        endpoint="/api/login",
+        json={"email": user_info.email, "password": new_password},
+    )
+
+
+def test_reset_password_user_cant_reset_another_users_password(
+    flask_client_with_db, dev_db_client, mocker
+):
+    user_info_1 = create_test_user_api(flask_client_with_db)
+    user_info_2 = create_test_user_api(flask_client_with_db)
+    password_digest_user_2 = dev_db_client.get_user_info(user_info_2.email).password_digest
+    password_digest_user_1 = dev_db_client.get_user_info(user_info_1.email).password_digest
+    token = request_reset_password_api(flask_client_with_db, mocker, user_info_1)
+    new_password = str(uuid.uuid4())
+
+    # Should get a bad request if user tries to reset another user's password
+    run_and_validate_request(
+        flask_client=flask_client_with_db,
+        http_method="post",
+        endpoint="/api/reset-password",
+        json={"email": user_info_2.email, "token": token, "password": new_password},
+        expected_response_status=HTTPStatus.BAD_REQUEST,
+    )
+
+    # Neither user should be able to login with the new password
+    run_and_validate_request(
+        flask_client=flask_client_with_db,
+        http_method="post",
+        endpoint="/api/login",
+        json={"email": user_info_2.email, "password": new_password},
+        expected_response_status=HTTPStatus.UNAUTHORIZED,
+    )
+
+    run_and_validate_request(
+        flask_client=flask_client_with_db,
+        http_method="post",
+        endpoint="/api/login",
+        json={"email": user_info_1.email, "password": new_password},
+        expected_response_status=HTTPStatus.UNAUTHORIZED,
+    )

--- a/tests/middleware/test_reset_token_queries.py
+++ b/tests/middleware/test_reset_token_queries.py
@@ -14,7 +14,7 @@ from middleware.primary_resource_logic.reset_token_queries import (
     InvalidTokenError,
 )
 from tests.helper_scripts.DynamicMagicMock import DynamicMagicMock
-
+from tests.fixtures import mock_flask_response_manager
 
 class RequestResetPasswordMocks(DynamicMagicMock):
     user_check_email: MagicMock
@@ -60,17 +60,19 @@ def setup_reset_password_mocks():
     yield mock
 
 
-def test_reset_password_happy_path(setup_reset_password_mocks):
+def test_reset_password_happy_path(setup_reset_password_mocks, mock_flask_response_manager):
     mock = setup_reset_password_mocks
 
     reset_password(mock.db_client, mock.dto)
 
     mock.invalid_token_response.assert_not_called()
-    mock.make_response.assert_called_once_with(
+    mock_flask_response_manager.make_response.assert_called_once_with(
         {"message": "Successfully updated password"}, HTTPStatus.OK
     )
     mock.set_user_password.assert_called_once_with(
-        mock.db_client, mock.email, mock.dto.token
+        db_client=mock.db_client,
+        email=mock.email,
+        password=mock.dto.password
     )
 
 


### PR DESCRIPTION
#### Fixes

* Addresses test case discussed in https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/162

#### Description

* Addresses test case of checking to make sure that a user cannot use their own reset password token to reset another user's password (and thereby be able to log in as them).
* Through the above test case, discovered a vulnerability that enabled the above scenario to occur, and resolved it.
* In so doing, discovered a bug in reset password (and the associated tests) where the _reset token_, rather than the new password the user provided, was being made into the new password hash, This would have prevented anyone from resetting their password. 
* The relevant integration was failing to check that a user could log in with the new password -- it merely checked that the new password hash and the old password hash were different. That test has been updated accordingly. 

#### Testing

* Run all tests in `tests` directory to confirm functionality. 

#### Performance

* Impact marginal

#### Docs

* Identified error in docs for `/reset-password`, where `new_password` input was not mentioned. Addressed. 

#### Breaking Changes

* None.