### PR TITLE
Mc 433 agencies typeahead

### DIFF
--- a/.github/workflows/bandit.yaml
+++ b/.github/workflows/bandit.yaml
@@ -25,7 +25,7 @@ jobs:
         bandit -r middleware resources app.py database_client
 
     - name: Upload Bandit results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: bandit-report
         path: bandit_output.txt

--- a/database_client/database_client.py
+++ b/database_client/database_client.py
@@ -609,7 +609,7 @@ class DatabaseClient:
         :param search_term: The search query.
         :return: List of data sources that match the search query.
         """
-        query = DynamicQueryConstructor.generate_new_typeahead_suggestion_query(
+        query = DynamicQueryConstructor.generate_new_typeahead_locations_query(
             search_term
         )
         self.cursor.execute(query)
@@ -624,7 +624,7 @@ class DatabaseClient:
         :return: List of data sources that match the search query.
         """
         # TODO: Change create new logic for this
-        query = DynamicQueryConstructor.generate_new_typeahead_suggestion_query(
+        query = DynamicQueryConstructor.generate_new_typeahead_locations_query(
             search_term
         )
         self.cursor.execute(query)

--- a/database_client/database_client.py
+++ b/database_client/database_client.py
@@ -621,10 +621,9 @@ class DatabaseClient:
         Returns a list of data sources that match the search query.
 
         :param search_term: The search query.
-        :return: List of data sources that match the search query.
+        :return: List of agencies that match the search query.
         """
-        # TODO: Change create new logic for this
-        query = DynamicQueryConstructor.generate_new_typeahead_locations_query(
+        query = DynamicQueryConstructor.generate_new_typeahead_agencies_query(
             search_term
         )
         self.cursor.execute(query)

--- a/database_client/database_client.py
+++ b/database_client/database_client.py
@@ -601,12 +601,8 @@ class DatabaseClient:
             email=results["email"],
         )
 
-    TypeaheadSuggestions = namedtuple(
-        "TypeaheadSuggestions", ["display_name", "type", "state", "county", "locality"]
-    )
-
     @cursor_manager()
-    def get_typeahead_suggestions(self, search_term: str) -> List[TypeaheadSuggestions]:
+    def get_typeahead_locations(self, search_term: str) -> dict:
         """
         Returns a list of data sources that match the search query.
 
@@ -617,18 +613,22 @@ class DatabaseClient:
             search_term
         )
         self.cursor.execute(query)
-        results = self.cursor.fetchall()
+        return self.cursor.fetchall()
 
-        return [
-            self.TypeaheadSuggestions(
-                display_name=row["display_name"],
-                type=row["type"],
-                state=row["state"],
-                county=row["county"],
-                locality=row["locality"],
-            )
-            for row in results
-        ]
+    @cursor_manager()
+    def get_typeahead_agencies(self, search_term: str) -> dict:
+        """
+        Returns a list of data sources that match the search query.
+
+        :param search_term: The search query.
+        :return: List of data sources that match the search query.
+        """
+        # TODO: Change create new logic for this
+        query = DynamicQueryConstructor.generate_new_typeahead_suggestion_query(
+            search_term
+        )
+        self.cursor.execute(query)
+        return self.cursor.fetchall()
 
     @cursor_manager()
     def search_with_location_and_record_type(

--- a/database_client/dynamic_query_constructor.py
+++ b/database_client/dynamic_query_constructor.py
@@ -160,16 +160,19 @@ class DynamicQueryConstructor:
             WHERE display_name ILIKE {search_term_anywhere}
             AND display_name NOT ILIKE {search_term_prefix}
         )
-        SELECT DISTINCT 
-            sort_order,
-            display_name,
-            type,
-            state,
-            county,
-            locality
-        FROM combined
-        ORDER BY sort_order, display_name
-        LIMIT 10;
+        SELECT display_name, type, state, county, locality
+        FROM (
+            SELECT DISTINCT 
+                sort_order,
+                display_name,
+                type,
+                state,
+                county,
+                locality
+            FROM combined
+            ORDER BY sort_order, display_name
+            LIMIT 10
+        ) as results;
         """
         ).format(
             search_term_prefix=sql.Literal(f"{search_term}%"),

--- a/database_client/dynamic_query_constructor.py
+++ b/database_client/dynamic_query_constructor.py
@@ -135,7 +135,7 @@ class DynamicQueryConstructor:
         ]
 
     @staticmethod
-    def generate_new_typeahead_suggestion_query(search_term: str):
+    def generate_new_typeahead_locations_query(search_term: str):
         query = sql.SQL(
             """
         WITH combined AS (
@@ -146,7 +146,7 @@ class DynamicQueryConstructor:
                 state,
                 county,
                 locality
-            FROM typeahead_suggestions
+            FROM typeahead_locations
             WHERE display_name ILIKE {search_term_prefix}
             UNION ALL
             SELECT
@@ -156,7 +156,7 @@ class DynamicQueryConstructor:
                 state,
                 county,
                 locality
-            FROM typeahead_suggestions
+            FROM typeahead_locations
             WHERE display_name ILIKE {search_term_anywhere}
             AND display_name NOT ILIKE {search_term_prefix}
         )

--- a/database_client/dynamic_query_constructor.py
+++ b/database_client/dynamic_query_constructor.py
@@ -206,10 +206,10 @@ class DynamicQueryConstructor:
             AND name NOT ILIKE {search_term}
         )
         SELECT
-            name,
+            name as display_name,
             jurisdiction_type,
-            state_iso,
-            municipality,
+            state_iso as state,
+            municipality as locality,
             county_name as county
         FROM (
             SELECT DISTINCT

--- a/database_client/dynamic_query_constructor.py
+++ b/database_client/dynamic_query_constructor.py
@@ -210,7 +210,7 @@ class DynamicQueryConstructor:
             jurisdiction_type,
             state_iso,
             municipality,
-            county_name
+            county_name as county
         FROM (
             SELECT DISTINCT
                 sort_order,

--- a/middleware/flask_response_manager.py
+++ b/middleware/flask_response_manager.py
@@ -17,7 +17,7 @@ class FlaskResponseManager:
     def make_response(
         cls,
         data: dict,
-        status_code: int,
+        status_code: HTTPStatus = HTTPStatus.OK,
         validation_schema: Optional[Type[Schema]] = None,
     ) -> Response:
         if validation_schema is not None:

--- a/middleware/primary_resource_logic/data_requests.py
+++ b/middleware/primary_resource_logic/data_requests.py
@@ -47,8 +47,10 @@ RELATED_SOURCES_RELATION = Relations.RELATED_SOURCES.value
 class RelatedSourceByIDSchema(GetByIDBaseSchema):
     data_source_id = fields.Str(
         required=True,
-        description="The ID of the data source",
-        source=SourceMappingEnum.PATH,
+        metadata={
+            "description": "The ID of the data source",
+            "source": SourceMappingEnum.PATH,
+        }
     )
 
 

--- a/middleware/primary_resource_logic/data_source_queries.py
+++ b/middleware/primary_resource_logic/data_source_queries.py
@@ -39,10 +39,12 @@ class DataSourceNotFoundError(Exception):
 class DataSourcesGetRequestSchemaMany(GetManyBaseSchema):
     approval_status = fields.Str(
         required=False,
-        description="Approval status of returned data sources.",
-        source=SourceMappingEnum.QUERY_ARGS,
         validate=validate.OneOf([e.value for e in ApprovalStatus]),
-        default="approved",
+        metadata={
+            "source": SourceMappingEnum.QUERY_ARGS,
+            "description": "The approval status of the data sources",
+            "default": "approved",
+        }
     )
 
 

--- a/middleware/primary_resource_logic/permissions_logic.py
+++ b/middleware/primary_resource_logic/permissions_logic.py
@@ -27,19 +27,25 @@ allowable_actions_str = "Allowable actions include: \n  * " + "\n  * ".join(
 class PermissionsRequestSchema(Schema):
     user_email = fields.Str(
         required=True,
-        description="The email of the user for which to retrieve permissions.",
-        location=ParserLocation.QUERY.value,
-        source=SourceMappingEnum.QUERY_ARGS,
+        metadata={
+            "description": "The email of the user for which to retrieve permissions.",
+            "source": SourceMappingEnum.QUERY_ARGS,
+            "location": ParserLocation.QUERY.value
+        }
     )
     permission = fields.Str(
         required=True,
-        description=f"The permission to add or remove. \n {allowable_permissions_str}",
-        source=SourceMappingEnum.JSON,
+        metadata={
+            "description": "The permission to add or remove. \n {allowable_permissions_str}",
+            "source": SourceMappingEnum.JSON
+        }
     )
     action = fields.Str(
         required=True,
-        description=f"The action to perform. \n {allowable_actions_str}",
-        source=SourceMappingEnum.JSON,
+        metadata={
+            "source": SourceMappingEnum.JSON,
+            "description": "The action to perform. \n {allowable_actions_str}",
+        }
     )
 
 @dataclass

--- a/middleware/primary_resource_logic/reset_token_queries.py
+++ b/middleware/primary_resource_logic/reset_token_queries.py
@@ -28,30 +28,40 @@ class RequestResetPasswordRequest:
 class RequestResetPasswordRequestSchema(Schema):
     email = fields.Str(
         required=True,
-        description="The email of the user",
-        source=SourceMappingEnum.JSON,
+        metadata={
+            "description": "The email of the user",
+            "source": SourceMappingEnum.JSON,
+        }
     )
     token = fields.Str(
         required=True,
-        description="The token of the user",
-        source=SourceMappingEnum.JSON,
+        metadata={
+            "description": "The token of the user",
+            "source": SourceMappingEnum.JSON,
+        }
     )
 
 class ResetPasswordSchema(Schema):
     email = fields.Str(
         required=True,
-        description="The email of the user",
-        source=SourceMappingEnum.JSON,
+        metadata={
+            "description": "The email of the user",
+            "source": SourceMappingEnum.JSON,
+        }
     )
     password = fields.Str(
         required=True,
-        description="The new password of the user",
-        source=SourceMappingEnum.JSON,
+        metadata={
+            "description": "The new password of the user",
+            "source": SourceMappingEnum.JSON,
+        }
     )
     token = fields.Str(
         required=True,
-        description="The user's reset password token",
-        source=SourceMappingEnum.JSON,
+        metadata={
+            "description": "The token of the user",
+            "source": SourceMappingEnum.JSON,
+        }
     )
 
 @dataclass

--- a/middleware/primary_resource_logic/search_logic.py
+++ b/middleware/primary_resource_logic/search_logic.py
@@ -22,9 +22,11 @@ def transform_record_categories(value: str) -> Optional[list[RecordCategories]]:
 class SearchRequestSchema(Schema):
     state = fields.Str(
         required=True,
-        description="The state of the search.",
-        location=ParserLocation.QUERY.value,
-        source=SourceMappingEnum.QUERY_ARGS,
+        metadata={
+            "description": "The state of the search.",
+            "source": SourceMappingEnum.QUERY_ARGS,
+            "location": ParserLocation.QUERY.value
+        }
     )
     record_categories = fields.Str(
         required=False,
@@ -34,19 +36,32 @@ class SearchRequestSchema(Schema):
         + "\n  * ".join([e.value for e in RecordCategories]),
         location=ParserLocation.QUERY.value,
         source=SourceMappingEnum.QUERY_ARGS,
-        transformation_function=transform_record_categories,
+        metadata={
+            "transformation_function": transform_record_categories,
+            "description": "The record categories of the search. If empty, all categories will be searched."
+                "Multiple record categories can be provided as a comma-separated list, eg. 'Police & Public "
+                           "Interactions,Agency-published Resources'."
+                "Allowable record categories include: \n  * "
+                + "\n  * ".join([e.value for e in RecordCategories]),
+            "source": SourceMappingEnum.QUERY_ARGS,
+            "location": ParserLocation.QUERY.value
+        }
     )
     county = fields.Str(
         required=False,
-        description="The county of the search. If empty, all counties for the given state will be searched.",
-        location=ParserLocation.QUERY.value,
-        source=SourceMappingEnum.QUERY_ARGS,
+        metadata={
+            "description": "The county of the search. If empty, all counties for the given state will be searched.",
+            "source": SourceMappingEnum.QUERY_ARGS,
+            "location": ParserLocation.QUERY.value
+        }
     )
     locality = fields.Str(
         required=False,
-        description="The locality of the search. If empty, all localities for the given county will be searched.",
-        location=ParserLocation.QUERY.value,
-        source=SourceMappingEnum.QUERY_ARGS,
+        metadata={
+            "description": "The locality of the search. If empty, all localities for the given county will be searched.",
+            "source": SourceMappingEnum.QUERY_ARGS,
+            "location": ParserLocation.QUERY.value
+        }
     )
 
 

--- a/middleware/primary_resource_logic/search_logic.py
+++ b/middleware/primary_resource_logic/search_logic.py
@@ -30,12 +30,6 @@ class SearchRequestSchema(Schema):
     )
     record_categories = fields.Str(
         required=False,
-        description="The record categories of the search. If empty, all categories will be searched."
-        "Multiple record categories can be provided as a comma-separated list, eg. 'Police & Public Interactions,Agency-published Resources'."
-        "Allowable record categories include: \n  * "
-        + "\n  * ".join([e.value for e in RecordCategories]),
-        location=ParserLocation.QUERY.value,
-        source=SourceMappingEnum.QUERY_ARGS,
         metadata={
             "transformation_function": transform_record_categories,
             "description": "The record categories of the search. If empty, all categories will be searched."

--- a/middleware/primary_resource_logic/typeahead_suggestion_logic.py
+++ b/middleware/primary_resource_logic/typeahead_suggestion_logic.py
@@ -97,11 +97,16 @@ class TypeaheadAgenciesOuterResponseSchema(Schema):
 
 
 class TypeaheadLocationsOuterResponseSchema(Schema):
-    suggestions = fields.Nested(
-        TypeaheadLocationsResponseSchema,
-        required=True,
-        description="The suggestions for the given query",
+
+    suggestions = fields.List(
+        cls_or_instance=fields.Nested(
+            nested=TypeaheadLocationsResponseSchema,
+            required=True,
+            description="The suggestions for the given query",
+            metadata=RESPONSE_METADATA,
+        ),
         metadata=RESPONSE_METADATA,
+        description="The suggestions for the given query",
     )
 
 

--- a/middleware/primary_resource_logic/typeahead_suggestion_logic.py
+++ b/middleware/primary_resource_logic/typeahead_suggestion_logic.py
@@ -31,22 +31,28 @@ RESPONSE_METADATA = {
 class TypeaheadBaseResponseSchema(Schema):
     state = fields.String(
         required=True,
-        description="The state of the suggestion",
         example="Pennsylvania",
-        metadata=RESPONSE_METADATA,
+        metadata={
+            "source": SourceMappingEnum.JSON,
+            "description": "The state of the suggestion",
+        },
     )
     county = fields.String(
         required=True,
-        description="The county of the suggestion",
         example="Allegheny",
-        metadata=RESPONSE_METADATA,
+        metadata={
+            "source": SourceMappingEnum.JSON,
+            "description": "The county of the suggestion",
+        },
         allow_none=True
     )
     locality = fields.String(
         required=True,
-        description="The locality of the suggestion",
         example="Pittsburgh",
-        metadata=RESPONSE_METADATA,
+        metadata={
+            "source": SourceMappingEnum.JSON,
+            "description": "The locality of the suggestion",
+        },
         allow_none=True
     )
 
@@ -55,32 +61,41 @@ class TypeaheadBaseResponseSchema(Schema):
 class TypeaheadLocationsResponseSchema(TypeaheadBaseResponseSchema):
     display_name = fields.String(
         required=True,
-        description="The display name of the suggestion",
         example="Pittsburgh",
-        metadata=RESPONSE_METADATA,
+        metadata={
+            "source": SourceMappingEnum.JSON,
+            "description": "The display name of the suggestion",
+        },
     )
     type = fields.String(
         required=True,
-        description="The type of suggestion.",
         example="Locality",
         validate=validate.OneOf(["State", "County", "Locality"]),
-        metadata=RESPONSE_METADATA,
+        metadata={
+            "source": SourceMappingEnum.JSON,
+            "description": "The type of suggestion.",
+        },
     )
 
 
 class TypeaheadAgenciesResponseSchema(TypeaheadBaseResponseSchema):
     display_name = fields.String(
         required=True,
-        description="The display name of the suggestion",
         example="Springfield Police Agency",
-        metadata=RESPONSE_METADATA,
+        metadata={
+            "source": SourceMappingEnum.JSON,
+            "description": "The display name of the suggestion",
+        },
     )
     jurisdiction_type = fields.String(
         required=True,
         description=f"The jurisdiction type.",
         validate=validate.OneOf(JURISDICTION_TYPES),
         example="school",
-        metadata=RESPONSE_METADATA,
+        metadata={
+            "source": SourceMappingEnum.JSON,
+            "description": "The type of suggestion.",
+        },
     )
 
 # TODO: Use these in the integration tests
@@ -90,11 +105,15 @@ class TypeaheadAgenciesOuterResponseSchema(Schema):
         cls_or_instance=fields.Nested(
             nested=TypeaheadAgenciesResponseSchema,
             required=True,
-            description="The suggestions for the given query",
-            metadata=RESPONSE_METADATA,
+            metadata={
+                "source": SourceMappingEnum.JSON,
+                "description": "The suggestions for the given query",
+            },
         ),
-        metadata=RESPONSE_METADATA,
-        description="The suggestions for the given query",
+        metadata={
+            "source": SourceMappingEnum.JSON,
+            "description": "The suggestions for the given query",
+        },
     )
 
 
@@ -104,11 +123,15 @@ class TypeaheadLocationsOuterResponseSchema(Schema):
         cls_or_instance=fields.Nested(
             nested=TypeaheadLocationsResponseSchema,
             required=True,
-            description="The suggestions for the given query",
-            metadata=RESPONSE_METADATA,
+            metadata={
+                "source": SourceMappingEnum.JSON,
+                "description": "The suggestions for the given query",
+            },
         ),
-        metadata=RESPONSE_METADATA,
-        description="The suggestions for the given query",
+        metadata={
+            "source": SourceMappingEnum.JSON,
+            "description": "The suggestions for the given query",
+        },
     )
 
 

--- a/middleware/primary_resource_logic/typeahead_suggestion_logic.py
+++ b/middleware/primary_resource_logic/typeahead_suggestion_logic.py
@@ -40,12 +40,14 @@ class TypeaheadBaseResponseSchema(Schema):
         description="The county of the suggestion",
         example="Allegheny",
         metadata=RESPONSE_METADATA,
+        allow_none=True
     )
     locality = fields.String(
         required=True,
         description="The locality of the suggestion",
         example="Pittsburgh",
         metadata=RESPONSE_METADATA,
+        allow_none=True
     )
 
 

--- a/middleware/primary_resource_logic/typeahead_suggestion_logic.py
+++ b/middleware/primary_resource_logic/typeahead_suggestion_logic.py
@@ -1,13 +1,111 @@
-from typing import Callable
+from typing import Callable, Type
+
+from marshmallow import Schema, fields, validate
+
 from database_client.database_client import DatabaseClient
-from middleware.schema_and_dto_logic.common_schemas_and_dtos import TypeaheadDTO, TypeaheadSchema
+from middleware.flask_response_manager import FlaskResponseManager
+from middleware.schema_and_dto_logic.common_schemas_and_dtos import (
+    TypeaheadDTO,
+    TypeaheadSchema,
+)
+from utilities.enums import SourceMappingEnum
+
+JURISDICTION_TYPES = [
+    "school",
+    None,
+    "county",
+    "local",
+    "port",
+    "tribal",
+    "transit",
+    "state",
+    "federal",
+]
+
+
+RESPONSE_METADATA = {
+    "source": SourceMappingEnum.JSON,
+}
+
+
+class TypeaheadBaseResponseSchema(Schema):
+    state = fields.String(
+        required=True,
+        description="The state of the suggestion",
+        example="Pennsylvania",
+        metadata=RESPONSE_METADATA,
+    )
+    county = fields.String(
+        required=True,
+        description="The county of the suggestion",
+        example="Allegheny",
+        metadata=RESPONSE_METADATA,
+    )
+    locality = fields.String(
+        required=True,
+        description="The locality of the suggestion",
+        example="Pittsburgh",
+        metadata=RESPONSE_METADATA,
+    )
+
+
+
+class TypeaheadLocationsResponseSchema(TypeaheadBaseResponseSchema):
+    display_name = fields.String(
+        required=True,
+        description="The display name of the suggestion",
+        example="Pittsburgh",
+        metadata=RESPONSE_METADATA,
+    )
+    type = fields.String(
+        required=True,
+        description="The type of suggestion.",
+        example="Locality",
+        validate=validate.OneOf(["State", "County", "Locality"]),
+        metadata=RESPONSE_METADATA,
+    )
+
+
+class TypeaheadAgenciesResponseSchema(TypeaheadBaseResponseSchema):
+    display_name = fields.String(
+        required=True,
+        description="The display name of the suggestion",
+        example="Springfield Police Agency",
+        metadata=RESPONSE_METADATA,
+    )
+    jurisdiction_type = fields.String(
+        required=True,
+        description=f"The jurisdiction type.",
+        validate=validate.OneOf(JURISDICTION_TYPES),
+        example="school",
+        metadata=RESPONSE_METADATA,
+    )
+
+# TODO: Use these in the integration tests
+class TypeaheadAgenciesOuterResponseSchema(Schema):
+    # pass
+    suggestions = fields.Nested(
+        TypeaheadAgenciesResponseSchema,
+        required=True,
+        description="The suggestions for the given query",
+        metadata=RESPONSE_METADATA,
+    )
+
+
+class TypeaheadLocationsOuterResponseSchema(Schema):
+    suggestions = fields.Nested(
+        TypeaheadLocationsResponseSchema,
+        required=True,
+        description="The suggestions for the given query",
+        metadata=RESPONSE_METADATA,
+    )
+
 
 def get_typeahead_results(
     db_client: DatabaseClient,
     dto: TypeaheadDTO,
-    db_client_method: Callable
+    db_client_method: Callable,
 ):
-    return {
-        "suggestions": db_client_method(db_client, dto.query)
-    }
-
+    return FlaskResponseManager.make_response(
+        data={"suggestions": db_client_method(db_client, dto.query)},
+    )

--- a/middleware/primary_resource_logic/typeahead_suggestion_logic.py
+++ b/middleware/primary_resource_logic/typeahead_suggestion_logic.py
@@ -31,27 +31,27 @@ RESPONSE_METADATA = {
 class TypeaheadBaseResponseSchema(Schema):
     state = fields.String(
         required=True,
-        example="Pennsylvania",
         metadata={
             "source": SourceMappingEnum.JSON,
             "description": "The state of the suggestion",
+            "example": "Pennsylvania",
         },
     )
     county = fields.String(
         required=True,
-        example="Allegheny",
         metadata={
             "source": SourceMappingEnum.JSON,
             "description": "The county of the suggestion",
+            "example": "Allegheny",
         },
         allow_none=True
     )
     locality = fields.String(
         required=True,
-        example="Pittsburgh",
         metadata={
             "source": SourceMappingEnum.JSON,
             "description": "The locality of the suggestion",
+            "example": "Pittsburgh",
         },
         allow_none=True
     )
@@ -61,19 +61,19 @@ class TypeaheadBaseResponseSchema(Schema):
 class TypeaheadLocationsResponseSchema(TypeaheadBaseResponseSchema):
     display_name = fields.String(
         required=True,
-        example="Pittsburgh",
         metadata={
             "source": SourceMappingEnum.JSON,
             "description": "The display name of the suggestion",
+            "example": "Pittsburgh",
         },
     )
     type = fields.String(
         required=True,
-        example="Locality",
         validate=validate.OneOf(["State", "County", "Locality"]),
         metadata={
             "source": SourceMappingEnum.JSON,
             "description": "The type of suggestion.",
+            "example": "Locality",
         },
     )
 
@@ -81,20 +81,19 @@ class TypeaheadLocationsResponseSchema(TypeaheadBaseResponseSchema):
 class TypeaheadAgenciesResponseSchema(TypeaheadBaseResponseSchema):
     display_name = fields.String(
         required=True,
-        example="Springfield Police Agency",
         metadata={
             "source": SourceMappingEnum.JSON,
             "description": "The display name of the suggestion",
+            "example": "Springfield County Sheriff's Office",
         },
     )
     jurisdiction_type = fields.String(
         required=True,
-        description=f"The jurisdiction type.",
         validate=validate.OneOf(JURISDICTION_TYPES),
-        example="school",
         metadata={
             "source": SourceMappingEnum.JSON,
-            "description": "The type of suggestion.",
+            "description": "The jurisdiction type.",
+            "example": "school",
         },
     )
 

--- a/middleware/primary_resource_logic/typeahead_suggestion_logic.py
+++ b/middleware/primary_resource_logic/typeahead_suggestion_logic.py
@@ -84,11 +84,15 @@ class TypeaheadAgenciesResponseSchema(TypeaheadBaseResponseSchema):
 # TODO: Use these in the integration tests
 class TypeaheadAgenciesOuterResponseSchema(Schema):
     # pass
-    suggestions = fields.Nested(
-        TypeaheadAgenciesResponseSchema,
-        required=True,
-        description="The suggestions for the given query",
+    suggestions = fields.List(
+        cls_or_instance=fields.Nested(
+            nested=TypeaheadAgenciesResponseSchema,
+            required=True,
+            description="The suggestions for the given query",
+            metadata=RESPONSE_METADATA,
+        ),
         metadata=RESPONSE_METADATA,
+        description="The suggestions for the given query",
     )
 
 

--- a/middleware/primary_resource_logic/typeahead_suggestion_logic.py
+++ b/middleware/primary_resource_logic/typeahead_suggestion_logic.py
@@ -1,19 +1,13 @@
-from http import HTTPStatus
-
-from flask import Response, make_response
-
+from typing import Callable
 from database_client.database_client import DatabaseClient
+from middleware.schema_and_dto_logic.common_schemas_and_dtos import TypeaheadDTO, TypeaheadSchema
 
+def get_typeahead_results(
+    db_client: DatabaseClient,
+    dto: TypeaheadDTO,
+    db_client_method: Callable
+):
+    return {
+        "suggestions": db_client_method(db_client, dto.query)
+    }
 
-def get_typeahead_dict_results(
-    suggestions: list[DatabaseClient.TypeaheadSuggestions],
-) -> list[dict]:
-    return [suggestion._asdict() for suggestion in suggestions]
-
-
-def get_typeahead_suggestions_wrapper(
-    db_client: DatabaseClient, query: str
-) -> Response:
-    suggestions = db_client.get_typeahead_suggestions(query)
-    dict_results = get_typeahead_dict_results(suggestions)
-    return make_response({"suggestions": dict_results}, HTTPStatus.OK)

--- a/middleware/primary_resource_logic/user_queries.py
+++ b/middleware/primary_resource_logic/user_queries.py
@@ -10,8 +10,20 @@ from utilities.enums import SourceMappingEnum
 
 
 class UserRequestSchema(Schema):
-    email = fields.Str(required=True, description="The email of the user", source=SourceMappingEnum.JSON)
-    password = fields.Str(required=True, description="The password of the user", source=SourceMappingEnum.JSON)
+    email = fields.Str(
+        required=True,
+        metadata={
+            "description": "The email of the user",
+            "source": SourceMappingEnum.JSON
+        }
+    )
+    password = fields.Str(
+        required=True,
+        metadata={
+            "description": "The password of the user",
+            "source": SourceMappingEnum.JSON
+        }
+    )
 
 @dataclass
 class UserRequest:

--- a/middleware/schema_and_dto_logic/common_schemas_and_dtos.py
+++ b/middleware/schema_and_dto_logic/common_schemas_and_dtos.py
@@ -103,3 +103,14 @@ class EntryDataRequestDTO:
             source=SourceMappingEnum.JSON,
             validation_schema=EntryDataRequestSchema,
         )
+
+class TypeaheadSchema(Schema):
+    query = fields.Str(
+        required=True,
+        description="The search query.",
+        metadata={"source": SourceMappingEnum.QUERY_ARGS},
+    )
+
+@dataclass
+class TypeaheadDTO:
+    query: str

--- a/middleware/schema_and_dto_logic/common_schemas_and_dtos.py
+++ b/middleware/schema_and_dto_logic/common_schemas_and_dtos.py
@@ -19,36 +19,35 @@ from utilities.enums import SourceMappingEnum
 class GetManyBaseSchema(Schema):
     page = fields.Integer(
         required=True,
-        description="The page number of the results to retrieve. Begins at 1.",
         validate=validate.Range(min=1),
-        default=1,
+        dump_default=1,
         metadata={
+            "description": "The page number of the results to retrieve. Begins at 1.",
             "source": SourceMappingEnum.QUERY_ARGS
         }
     )
     sort_by = fields.Str(
         required=False,
-        description="The field to sort the results by.",
         metadata={
+            "description": "The field to sort the results by.",
             "source": SourceMappingEnum.QUERY_ARGS
         }
     )
     sort_order = fields.Str(
         required=False,
-        description="The order to sort the results by.",
         validate=validate.OneOf([e.value for e in SortOrder]),
         metadata={
             "transformation_function": lambda value: get_valid_enum_value(SortOrder, value),
-            "source": SourceMappingEnum.QUERY_ARGS
-
+            "source": SourceMappingEnum.QUERY_ARGS,
+            "description": "The order to sort the results by.",
         }
     )
     requested_columns = fields.Str(
         required=False,
-        description="A comma-delimited list of the columns to return in the results. Defaults to all permitted if not provided.",
         metadata={
             "source": SourceMappingEnum.QUERY_ARGS,
-            "transformation_function": lambda value: value.split(",")
+            "transformation_function": lambda value: value.split(","),
+            "description": "A comma-delimited list of the columns to return in the results. Defaults to all permitted if not provided.",
         }
 
     )
@@ -68,9 +67,9 @@ class GetManyBaseDTO:
 class GetByIDBaseSchema(Schema):
     resource_id = fields.Str(
         required=True,
-        description="The ID of the object to retrieve.",
         metadata={
-            "source": SourceMappingEnum.PATH
+            "source": SourceMappingEnum.PATH,
+            "description": "The ID of the object to retrieve.",
         }
     )
 
@@ -81,8 +80,10 @@ class GetByIDBaseDTO:
 class EntryDataRequestSchema(Schema):
     entry_data = DataField(
         required=True,
-        description="The entry data field for adding and updating entries",
-        metadata={"source": SourceMappingEnum.JSON},
+        metadata={
+            "source": SourceMappingEnum.JSON,
+            "description": "The entry data field for adding and updating entries",
+        },
     )
 
 
@@ -119,8 +120,10 @@ class EntryDataRequestDTO:
 class TypeaheadSchema(Schema):
     query = fields.Str(
         required=True,
-        description="The search query to get suggestions for.",
-        metadata={"source": SourceMappingEnum.QUERY_ARGS},
+        metadata={
+            "source": SourceMappingEnum.QUERY_ARGS,
+            "description": "The search query to get suggestions for.",
+        },
     )
 
 @dataclass

--- a/middleware/schema_and_dto_logic/common_schemas_and_dtos.py
+++ b/middleware/schema_and_dto_logic/common_schemas_and_dtos.py
@@ -107,7 +107,7 @@ class EntryDataRequestDTO:
 class TypeaheadSchema(Schema):
     query = fields.Str(
         required=True,
-        description="The search query.",
+        description="The search query to get suggestions for.",
         metadata={"source": SourceMappingEnum.QUERY_ARGS},
     )
 

--- a/middleware/schema_and_dto_logic/common_schemas_and_dtos.py
+++ b/middleware/schema_and_dto_logic/common_schemas_and_dtos.py
@@ -20,27 +20,37 @@ class GetManyBaseSchema(Schema):
     page = fields.Integer(
         required=True,
         description="The page number of the results to retrieve. Begins at 1.",
-        source=SourceMappingEnum.QUERY_ARGS,
         validate=validate.Range(min=1),
         default=1,
+        metadata={
+            "source": SourceMappingEnum.QUERY_ARGS
+        }
     )
     sort_by = fields.Str(
         required=False,
         description="The field to sort the results by.",
-        source=SourceMappingEnum.QUERY_ARGS,
+        metadata={
+            "source": SourceMappingEnum.QUERY_ARGS
+        }
     )
     sort_order = fields.Str(
         required=False,
         description="The order to sort the results by.",
-        source=SourceMappingEnum.QUERY_ARGS,
         validate=validate.OneOf([e.value for e in SortOrder]),
-        transformation_function=lambda value: get_valid_enum_value(SortOrder, value),
+        metadata={
+            "transformation_function": lambda value: get_valid_enum_value(SortOrder, value),
+            "source": SourceMappingEnum.QUERY_ARGS
+
+        }
     )
     requested_columns = fields.Str(
         required=False,
         description="A comma-delimited list of the columns to return in the results. Defaults to all permitted if not provided.",
-        source=SourceMappingEnum.QUERY_ARGS,
-        transformation_function=lambda value: value.split(","),
+        metadata={
+            "source": SourceMappingEnum.QUERY_ARGS,
+            "transformation_function": lambda value: value.split(",")
+        }
+
     )
 
 
@@ -59,7 +69,9 @@ class GetByIDBaseSchema(Schema):
     resource_id = fields.Str(
         required=True,
         description="The ID of the object to retrieve.",
-        source=SourceMappingEnum.PATH,
+        metadata={
+            "source": SourceMappingEnum.PATH
+        }
     )
 
 @dataclass
@@ -70,7 +82,7 @@ class EntryDataRequestSchema(Schema):
     entry_data = DataField(
         required=True,
         description="The entry data field for adding and updating entries",
-        source=SourceMappingEnum.JSON,
+        metadata={"source": SourceMappingEnum.JSON},
     )
 
 

--- a/middleware/schema_and_dto_logic/custom_types.py
+++ b/middleware/schema_and_dto_logic/custom_types.py
@@ -19,6 +19,7 @@ RestxFields = Union[
     restx_fields.Integer,
     restx_fields.Boolean,
     restx_fields.List,
+    restx_fields.Nested,
     RestxModelPlaceholder
 ]
 DTOTypes = TypeVar("DTOTypes")

--- a/middleware/schema_and_dto_logic/dynamic_schema_documentation_construction.py
+++ b/middleware/schema_and_dto_logic/dynamic_schema_documentation_construction.py
@@ -166,14 +166,30 @@ class RestxModelBuilder(RestxBuilder):
     def add_field(self, field_info: FieldInfo):
         fi = field_info
         if fi.restx_field_type in [e for e in RestxModelPlaceholder]:
-            self.build_restx_submodel(fi.restx_field_type, fi)
+            field = self.build_restx_submodel(fi.restx_field_type, fi)
         elif fi.restx_field_type == restx_fields.Nested:
-            self._build_nested_field_as_model(fi)
+            field = self._build_nested_field_as_model(fi)
+        elif fi.restx_field_type == restx_fields.List:
+            field = self.add_list_field(fi)
 
         else:
-            self.model_dict[fi.field_name] = fi.restx_field_type(
+            field = fi.restx_field_type(
                 required=fi.required, description=fi.description
             )
+
+        self.model_dict[fi.field_name] = field
+
+    def _get_restx_field(self, fi: FieldInfo) -> Type[RestxFields]:
+
+    # TODO: create "get_field" method, or "FieldGetter" class, which is
+    #  then inserted into self.model_dict
+
+    def add_list_field(self, fi: FieldInfo):
+        # Get interior field of Marshmallow List
+
+        # Create list with same interior field for Restx
+
+        #
 
     def build_restx_submodel(self, placeholder: RestxModelPlaceholder, fi: FieldInfo):
         """
@@ -184,13 +200,13 @@ class RestxModelBuilder(RestxBuilder):
         """
 
         if placeholder == RestxModelPlaceholder.VARIABLE_COLUMNS:
-            self.model_dict[fi.field_name] = restx_fields.Nested(
+            return restx_fields.Nested(
                 create_variable_columns_model(
                     namespace=self.namespace, name_snake_case=fi.field_name
                 )
             )
         elif placeholder == RestxModelPlaceholder.LIST_VARIABLE_COLUMNS:
-            self.model_dict[fi.field_name] = restx_fields.List(
+            return restx_fields.List(
                 restx_fields.Nested(
                     create_variable_columns_model(
                         namespace=self.namespace, name_snake_case="result"
@@ -213,7 +229,7 @@ class RestxModelBuilder(RestxBuilder):
         submodel_builder.add_fields(fields)
         submodel = submodel_builder.build_model()
 
-        self.model_dict[fi.field_name] = restx_fields.Nested(
+        return restx_fields.Nested(
             submodel, required=fi.required, description=fi.description
         )
 

--- a/middleware/schema_and_dto_logic/dynamic_schema_documentation_construction.py
+++ b/middleware/schema_and_dto_logic/dynamic_schema_documentation_construction.py
@@ -20,25 +20,33 @@ This is because the request-friendly format is a string of comma-delimited value
 and the native format is a list, which the request-friendly format is converted to.
 """
 
+from abc import ABC, abstractmethod
 from typing import Optional, Type
 
 from flask_restx.reqparse import RequestParser
 
-from flask_restx import fields as restx_fields, Namespace
+from flask_restx import fields as restx_fields, Namespace, Model
 from marshmallow import fields as marshmallow_fields
 from marshmallow.validate import OneOf
 
-from middleware.schema_and_dto_logic.mappings import MARSHMALLOW_TO_RESTX_FIELD_MAPPING, \
-    RESTX_FIELD_TO_NATIVE_TYPE_MAPPING
+from middleware.schema_and_dto_logic.mappings import (
+    MARSHMALLOW_TO_RESTX_FIELD_MAPPING,
+    RESTX_FIELD_TO_NATIVE_TYPE_MAPPING,
+)
 from middleware.schema_and_dto_logic.non_dto_dataclasses import FlaskRestxDocInfo
 from middleware.schema_and_dto_logic.enums import RestxModelPlaceholder
-from middleware.schema_and_dto_logic.custom_types import MarshmallowFields, RestxFields, SchemaTypes
-from middleware.schema_and_dto_logic.restx_param_intermediate_objects import RestxParamIntermediateObjects
+from middleware.schema_and_dto_logic.custom_types import (
+    MarshmallowFields,
+    RestxFields,
+    SchemaTypes,
+)
+
 from middleware.schema_and_dto_logic.util import _get_required_argument
 from resources.resource_helpers import create_variable_columns_model
 from utilities.enums import SourceMappingEnum
 
 
+# region Supporting Functions
 def get_location(source: SourceMappingEnum) -> str:
     if source == SourceMappingEnum.PATH:
         return "path"
@@ -61,103 +69,185 @@ def add_description_info_from_validators(
     return description
 
 
-class RestxFieldBuilder:
-    """
-    Builds a Restx field from a marshmallow field
-    """
+# endregion
+
+
+# region Classes
+class FieldInfo:
 
     def __init__(
         self,
         field_name: str,
         field_value: marshmallow_fields.Field,
         schema_class: Type[SchemaTypes],
-        namespace: Namespace
     ):
-        self.namespace = namespace
         self.field_name = field_name
         self.field_value = field_value
         self.schema_class = schema_class
         self.metadata = field_value.metadata
-        self.description = self._get_description()
+        self.description = self._get_description(
+            self.metadata, self.schema_class, self.field_value
+        )
         self.required = field_value.required
         self.restx_field_type = self._map_field_type(type(field_value))
         self.source = _get_required_argument("source", self.metadata, self.schema_class)
 
-    def _get_description(self) -> str:
-        description = _get_required_argument(
-            "description", self.metadata, self.schema_class
-        )
-        return add_description_info_from_validators(self.field_value, description)
+    def _get_description(
+        self,
+        metadata: dict,
+        schema_class: Type[SchemaTypes],
+        field_value: marshmallow_fields,
+    ) -> str:
+        description = _get_required_argument("description", metadata, schema_class)
+        return add_description_info_from_validators(field_value, description)
 
     def _map_field_type(self, field_type: type[MarshmallowFields]) -> Type[RestxFields]:
         try:
             return MARSHMALLOW_TO_RESTX_FIELD_MAPPING[field_type]
         except KeyError:
-            raise NotImplementedError(f"The marshmallow field type {field_type} is not currently supported for Restx field conversion")
+            raise NotImplementedError(
+                f"The marshmallow field type {field_type} is not currently supported for Restx field conversion"
+            )
 
-    def _map_native_type(self, restx_field_type: Type[RestxFields]) -> type:
+    def map_native_type(self, restx_field_type: Type[RestxFields]) -> type:
         try:
             return RESTX_FIELD_TO_NATIVE_TYPE_MAPPING[restx_field_type]
         except KeyError:
-            raise NotImplementedError(f"The restx field type {restx_field_type} is not currently supported for mapping to a native python type")
-
-    def build_restx_field(self, intermediate_object: RestxParamIntermediateObjects):
-        if self.source == SourceMappingEnum.JSON:
-            return self._build_json_field_as_model(intermediate_object.restx_model_dict)
-        elif self.source in (SourceMappingEnum.QUERY_ARGS, SourceMappingEnum.PATH):
-            return self._build_query_or_path_field(intermediate_object.parser)
-        else:
-            raise Exception(f"Source {self.source.value} not supported")
-
-    def build_restx_model(
-            self,
-            placeholder: RestxModelPlaceholder,
-            restx_model_dict: dict
-    ):
-        if placeholder == RestxModelPlaceholder.VARIABLE_COLUMNS:
-            restx_model_dict[self.field_name] = restx_fields.Nested(create_variable_columns_model(
-                namespace=self.namespace,
-                name_snake_case=self.field_name
-            ))
-        elif placeholder == RestxModelPlaceholder.LIST_VARIABLE_COLUMNS:
-            restx_model_dict[self.field_name] = restx_fields.List(
-                restx_fields.Nested(
-                    create_variable_columns_model(
-                        namespace=self.namespace,
-                        name_snake_case="result"
-                    )
-                ),
-                attribute=self.field_name
+            raise NotImplementedError(
+                f"The restx field type {restx_field_type} is not currently supported for mapping to a native python type"
             )
 
+    def get_location(self, source: SourceMappingEnum) -> str:
+        return get_location(source)
 
-    def _build_json_field_as_model(
-        self, restx_model_dict: dict
-    ):
-        if self.restx_field_type in [e for e in RestxModelPlaceholder]:
-            self.build_restx_model(
-                self.restx_field_type,
-                restx_model_dict
-            )
-        else:
-            restx_model_dict[self.field_name] = self.restx_field_type(
-                required=self.required, description=self.description
-            )
 
-    def _build_query_or_path_field(
-        self, parser: RequestParser
-    ):
-        parser.add_argument(
-            self.field_name,
-            type=self._map_native_type(self.restx_field_type),
-            required=self.required,
-            location=self._get_location(self.source),
-            help=self.description,
-            default=self.metadata.get("default"),
+# region Restx Builders
+class RestxBuilder(ABC):
+
+    def add_fields(self, fields: list[FieldInfo]):
+        for field in fields:
+            self.add_field(field)
+
+    @abstractmethod
+    def add_field(self, fi: FieldInfo):
+        raise NotImplementedError
+
+
+class RestxParserBuilder(RestxBuilder):
+    """
+    Builds a Restx parser from Marshmallow fields
+    """
+
+    def __init__(self, parser: RequestParser):
+        self.parser = parser
+
+    def add_field(self, field_info: FieldInfo):
+        fi = field_info
+        self.parser.add_argument(
+            fi.field_name,
+            type=fi.map_native_type(fi.restx_field_type),
+            required=fi.required,
+            location=fi.get_location(fi.source),
+            help=fi.description,
+            default=fi.metadata.get("default"),
         )
 
-    def _get_location(self, source: SourceMappingEnum) -> str:
-        return get_location(source)
+
+class RestxModelBuilder(RestxBuilder):
+    """
+    Builds a Restx model from a marshmallow schema
+    """
+
+    def __init__(self, namespace: Namespace, model_name: Optional[str] = None):
+        self.namespace = namespace
+        self.model_name = model_name
+        self.model_dict = {}
+
+    def add_field(self, field_info: FieldInfo):
+        fi = field_info
+        if fi.restx_field_type in [e for e in RestxModelPlaceholder]:
+            self.build_restx_submodel(fi.restx_field_type, fi)
+        elif fi.restx_field_type == restx_fields.Nested:
+            self._build_nested_field_as_model(fi)
+
+        else:
+            self.model_dict[fi.field_name] = fi.restx_field_type(
+                required=fi.required, description=fi.description
+            )
+
+    def build_restx_submodel(self, placeholder: RestxModelPlaceholder, fi: FieldInfo):
+        """
+        Build a model that will be placed within the model
+        :param placeholder:
+        :param fi:
+        :return:
+        """
+
+        if placeholder == RestxModelPlaceholder.VARIABLE_COLUMNS:
+            self.model_dict[fi.field_name] = restx_fields.Nested(
+                create_variable_columns_model(
+                    namespace=self.namespace, name_snake_case=fi.field_name
+                )
+            )
+        elif placeholder == RestxModelPlaceholder.LIST_VARIABLE_COLUMNS:
+            self.model_dict[fi.field_name] = restx_fields.List(
+                restx_fields.Nested(
+                    create_variable_columns_model(
+                        namespace=self.namespace, name_snake_case="result"
+                    )
+                ),
+                attribute=fi.field_name,
+            )
+
+    def build_model(self) -> Model:
+        return self.namespace.model(self.model_name, self.model_dict)
+
+    def _build_nested_field_as_model(self, fi: FieldInfo):
+        sub_schema = fi.schema_class().fields[fi.field_name].schema
+        sub_schema_class = type(sub_schema)
+        fields = MarshmallowFieldSorter(sub_schema_class).model_fields
+        submodel_builder = RestxModelBuilder(
+            namespace=self.namespace,
+            model_name=f"{self.model_name} {fi.field_name}",
+        )
+        submodel_builder.add_fields(fields)
+        submodel = submodel_builder.build_model()
+
+        self.model_dict[fi.field_name] = restx_fields.Nested(
+            submodel, required=fi.required, description=fi.description
+        )
+
+
+# endregion
+
+
+class MarshmallowFieldSorter:
+    """
+    Sorts Marshmallow fields into either a list of parser fields and a list of model fields
+    """
+
+    def __init__(self, schema_class: type[SchemaTypes]):
+        self.parser_fields = []
+        self.model_fields = []
+        self.sort_fields(schema_class)
+
+    def sort_fields(self, schema_class: type[SchemaTypes]):
+        fields = schema_class().fields
+        for field_name, field_value in fields.items():
+            fi = FieldInfo(
+                field_name=field_name,
+                field_value=field_value,
+                schema_class=schema_class,
+            )
+            self._sort_field(fi)
+
+    def _sort_field(self, fi: FieldInfo):
+        if fi.source in (SourceMappingEnum.QUERY_ARGS, SourceMappingEnum.PATH):
+            self.parser_fields.append(fi)
+        elif fi.source == SourceMappingEnum.JSON:
+            self.model_fields.append(fi)
+        else:
+            raise Exception(f"Source {fi.source} not supported")
 
 
 class RestxParamDocumentationBuilder:
@@ -167,29 +257,31 @@ class RestxParamDocumentationBuilder:
         schema_class: Type[SchemaTypes],
         model_name: Optional[str] = None,
     ):
-        model_name = model_name or schema_class.__name__  #
-        self.intermediate_object = RestxParamIntermediateObjects(namespace, model_name)
+        model_name = model_name or schema_class.__name__
+        self.parser_builder = RestxParserBuilder(namespace.parser())
+        self.model_builder = RestxModelBuilder(
+            namespace=namespace, model_name=model_name
+        )
         self.namespace = namespace  #
         self.schema_class = schema_class
-        self.restx_model_dict = {}  #
-        self.parser = self.namespace.parser()  #
 
     def build(self) -> FlaskRestxDocInfo:
         self._populate_fields()
-        return self.intermediate_object.construct_doc_info()
+        return FlaskRestxDocInfo(
+            model=self.model_builder.build_model(),
+            parser=self.parser_builder.parser,
+        )
 
     def _populate_fields(self):
-        fields = self.schema_class().fields
-        for field_name, field_value in fields.items():
-            self._process_field(field_name, field_value)
-
-    def _process_field(self, field_name: str, field_value: marshmallow_fields.Field):
-        field_builder = RestxFieldBuilder(field_name, field_value, self.schema_class, self.namespace)
-        field_builder.build_restx_field(self.intermediate_object)
+        field_sorter = MarshmallowFieldSorter(self.schema_class)
+        self.parser_builder.add_fields(field_sorter.parser_fields)
+        self.model_builder.add_fields(field_sorter.model_fields)
 
 
 def get_restx_param_documentation(
-    namespace: Namespace, schema_class: Type[SchemaTypes], model_name: Optional[str] = None
+    namespace: Namespace,
+    schema_class: Type[SchemaTypes],
+    model_name: Optional[str] = None,
 ):
     """
     Takes a Marshmallow schema class with custom arguments and
@@ -207,3 +299,4 @@ def get_restx_param_documentation(
     return builder.build()
 
 
+# endregion

--- a/middleware/schema_and_dto_logic/mappings.py
+++ b/middleware/schema_and_dto_logic/mappings.py
@@ -13,6 +13,7 @@ MARSHMALLOW_TO_RESTX_FIELD_MAPPING = {
     marshmallow_fields.Bool: restx_fields.Boolean,
     marshmallow_fields.Email: restx_fields.String,  # Email can map to a String field in flask_restx
     marshmallow_fields.List: restx_fields.List,
+    marshmallow_fields.Nested: restx_fields.Nested,
     DataField: RestxModelPlaceholder.VARIABLE_COLUMNS,
     EntryDataListField: RestxModelPlaceholder.LIST_VARIABLE_COLUMNS,
     # Add more mappings as needed

--- a/middleware/schema_and_dto_logic/response_schemas.py
+++ b/middleware/schema_and_dto_logic/response_schemas.py
@@ -11,32 +11,42 @@ from utilities.enums import SourceMappingEnum
 
 class IDAndMessageSchema(Schema):
     id = fields.String(
-        description="The id of the created entry",
         required=True,
-        source=SourceMappingEnum.JSON,
+        metadata={
+            "description": "The id of the created entry",
+            "source": SourceMappingEnum.JSON,
+        }
     )
     message = fields.String(
-        description="The success message",
         example="Success. Entry created",
         required=True,
-        source=SourceMappingEnum.JSON,
+        metadata={
+            "description": "The success message",
+            "source": SourceMappingEnum.JSON,
+        }
     )
 
 
 class GetManyResponseSchema(Schema):
     message = fields.String(
-        description="The success message",
-        source=SourceMappingEnum.JSON,
+        metadata={
+            "description": "The success message",
+            "source": SourceMappingEnum.JSON,
+        }
     )
     count = fields.Integer(
-        description="The total number of results",
-        source=SourceMappingEnum.JSON,
+        metadata={
+            "description": "The total number of results",
+            "source": SourceMappingEnum.JSON,
+        }
     )
     data = EntryDataListField(
         fields.Dict,
-        description="The list of results",
         required=True,
-        source=SourceMappingEnum.JSON,
+        metadata={
+            "description": "The list of results",
+            "source": SourceMappingEnum.JSON,
+        }
     )
 
 
@@ -49,13 +59,17 @@ class EntryDataResponseSchema(Schema):
     rather than provided
     """
     message = fields.String(
-        description="The success message",
         example="Success. Entry created",
         required=True,
-        source=SourceMappingEnum.JSON,
+        metadata={
+            "description": "The success message",
+            "source": SourceMappingEnum.JSON,
+        }
     )
     data = DataField(
         required=True,
-        description="The data for the given entry",
-        source=SourceMappingEnum.JSON,
+        metadata={
+            "description": "The data for the given entry",
+            "source": SourceMappingEnum.JSON,
+        }
     )

--- a/middleware/schema_and_dto_logic/response_schemas.py
+++ b/middleware/schema_and_dto_logic/response_schemas.py
@@ -18,11 +18,11 @@ class IDAndMessageSchema(Schema):
         }
     )
     message = fields.String(
-        example="Success. Entry created",
         required=True,
         metadata={
             "description": "The success message",
             "source": SourceMappingEnum.JSON,
+            "example": "Success. Entry created",
         }
     )
 
@@ -59,11 +59,11 @@ class EntryDataResponseSchema(Schema):
     rather than provided
     """
     message = fields.String(
-        example="Success. Entry created",
         required=True,
         metadata={
             "description": "The success message",
             "source": SourceMappingEnum.JSON,
+            "example": "Success. Entry created",
         }
     )
     data = DataField(

--- a/resources/TypeaheadSuggestions.py
+++ b/resources/TypeaheadSuggestions.py
@@ -1,20 +1,23 @@
 from typing import Callable
 
-from flask import Response, request
-from flask_restx import fields, reqparse
+from flask import Response
 
 from config import limiter
 from database_client.database_client import DatabaseClient
 from middleware.primary_resource_logic.typeahead_suggestion_logic import (
     get_typeahead_results,
+    TypeaheadLocationsOuterResponseSchema,
+    TypeaheadAgenciesOuterResponseSchema,
 )
 from middleware.schema_and_dto_logic.common_schemas_and_dtos import (
     TypeaheadSchema,
     TypeaheadDTO,
 )
+from middleware.schema_and_dto_logic.dynamic_schema_documentation_construction import (
+    get_restx_param_documentation,
+)
 from middleware.schema_and_dto_logic.non_dto_dataclasses import SchemaPopulateParameters
 from resources.PsycopgResource import handle_exceptions, PsycopgResource
-from resources.resource_helpers import create_outer_model
 
 from utilities.namespace import create_namespace, AppNamespaces
 
@@ -22,52 +25,68 @@ namespace_typeahead_suggestions = create_namespace(
     namespace_attributes=AppNamespaces.TYPEAHEAD
 )
 
-request_parser = reqparse.RequestParser()
-request_parser.add_argument(
-    "query",
-    type=str,
-    location="args",
-    required=True,
-    help="The typeahead query to get suggestions for, such as `Pitts`",
+# request_parser = reqparse.RequestParser()
+# request_parser.add_argument(
+#     "query",
+#     type=str,
+#     location="args",
+#     required=True,
+#     help="The typeahead query to get suggestions for, such as `Pitts`",
+# )
+
+query_doc_info = get_restx_param_documentation(
+    namespace=namespace_typeahead_suggestions,
+    schema_class=TypeaheadSchema,
 )
 
-
-typeahead_suggestions_inner_model = namespace_typeahead_suggestions.model(
-    "TypeaheadSuggestionsInner",
-    {
-        "display_name": fields.String(
-            required=True,
-            description="The display name of the suggestion",
-            example="Pittsburgh",
-        ),
-        "type": fields.String(
-            required=True,
-            description="The type of suggestion. Either `State`, `County` or `Locality`",
-            example="Locality",
-        ),
-        "state": fields.String(
-            required=True,
-            description="The state of the suggestion",
-            example="Pennsylvania",
-        ),
-        "county": fields.String(
-            required=True,
-            description="The county of the suggestion",
-            example="Allegheny",
-        ),
-        "locality": fields.String(
-            required=True,
-            description="The locality of the suggestion",
-            example="Pittsburgh",
-        ),
-    },
+locations_doc_info = get_restx_param_documentation(
+    namespace=namespace_typeahead_suggestions,
+    schema_class=TypeaheadLocationsOuterResponseSchema,
 )
 
-typeahead_suggestions_outer_model = create_outer_model(
-    namespace_typeahead_suggestions,
-    typeahead_suggestions_inner_model,
-    "TypeaheadSuggestionsOuter",
+agencies_doc_info = get_restx_param_documentation(
+    namespace=namespace_typeahead_suggestions,
+    schema_class=TypeaheadAgenciesOuterResponseSchema,
 )
+
+#
+# # TODO: update doc
+# typeahead_suggestions_inner_model = namespace_typeahead_suggestions.model(
+#     "TypeaheadSuggestionsInner",
+#     {
+#         "display_name": fields.String(
+#             required=True,
+#             description="The display name of the suggestion",
+#             example="Pittsburgh",
+#         ),
+#         "type": fields.String(
+#             required=True,
+#             description="The type of suggestion. Either `State`, `County` or `Locality`",
+#             example="Locality",
+#         ),
+#         "state": fields.String(
+#             required=True,
+#             description="The state of the suggestion",
+#             example="Pennsylvania",
+#         ),
+#         "county": fields.String(
+#             required=True,
+#             description="The county of the suggestion",
+#             example="Allegheny",
+#         ),
+#         "locality": fields.String(
+#             required=True,
+#             description="The locality of the suggestion",
+#             example="Pittsburgh",
+#         ),
+#     },
+# )
+#
+# typeahead_locations_outer_model = create_outer_model(
+#     namespace_typeahead_suggestions,
+#     typeahead_suggestions_inner_model,
+#     "TypeaheadSuggestionsOuter",
+# )
 
 
 def get_typeahead_kwargs(db_client_method: Callable) -> dict:
@@ -85,11 +104,14 @@ def get_typeahead_kwargs(db_client_method: Callable) -> dict:
 class TypeaheadLocations(PsycopgResource):
 
     @handle_exceptions
-    @namespace_typeahead_suggestions.expect(request_parser)
-    @namespace_typeahead_suggestions.response(
-        200, "OK", typeahead_suggestions_outer_model
+    @namespace_typeahead_suggestions.doc(
+        description="Get suggestions for a typeahead query",
+        expect=[query_doc_info.parser],
+        responses={
+            200: ("OK. Suggestions returned.", locations_doc_info.model),
+            500: "Internal server error",
+        },
     )
-    @namespace_typeahead_suggestions.response(500, "Internal server error")
     @limiter.limit("10/second")
     def get(self) -> Response:
         """
@@ -109,6 +131,14 @@ class TypeaheadAgencies(PsycopgResource):
 
     @handle_exceptions
     @limiter.limit("10/second")
+    @namespace_typeahead_suggestions.doc(
+        description="Get suggestions for a typeahead query",
+        expect=[query_doc_info.parser],
+        responses={
+            200: ("OK. Suggestions returned.", agencies_doc_info.model),
+            500: "Internal server error",
+        },
+    )
     def get(self):
         return self.run_endpoint(
             **get_typeahead_kwargs(DatabaseClient.get_typeahead_agencies)

--- a/resources/TypeaheadSuggestions.py
+++ b/resources/TypeaheadSuggestions.py
@@ -9,7 +9,7 @@ from resources.resource_helpers import create_outer_model
 from utilities.namespace import create_namespace, AppNamespaces
 
 namespace_typeahead_suggestions = create_namespace(
-    namespace_attributes=AppNamespaces.SEARCH
+    namespace_attributes=AppNamespaces.TYPEAHEAD
 )
 
 request_parser = reqparse.RequestParser()
@@ -60,7 +60,7 @@ typeahead_suggestions_outer_model = create_outer_model(
 )
 
 
-@namespace_typeahead_suggestions.route("/typeahead-suggestions")
+@namespace_typeahead_suggestions.route("/locations")
 class TypeaheadSuggestions(PsycopgResource):
 
     @handle_exceptions

--- a/resources/TypeaheadSuggestions.py
+++ b/resources/TypeaheadSuggestions.py
@@ -25,15 +25,6 @@ namespace_typeahead_suggestions = create_namespace(
     namespace_attributes=AppNamespaces.TYPEAHEAD
 )
 
-# request_parser = reqparse.RequestParser()
-# request_parser.add_argument(
-#     "query",
-#     type=str,
-#     location="args",
-#     required=True,
-#     help="The typeahead query to get suggestions for, such as `Pitts`",
-# )
-
 query_doc_info = get_restx_param_documentation(
     namespace=namespace_typeahead_suggestions,
     schema_class=TypeaheadSchema,
@@ -48,46 +39,6 @@ agencies_doc_info = get_restx_param_documentation(
     namespace=namespace_typeahead_suggestions,
     schema_class=TypeaheadAgenciesOuterResponseSchema,
 )
-
-#
-# # TODO: update doc
-# typeahead_suggestions_inner_model = namespace_typeahead_suggestions.model(
-#     "TypeaheadSuggestionsInner",
-#     {
-#         "display_name": fields.String(
-#             required=True,
-#             description="The display name of the suggestion",
-#             example="Pittsburgh",
-#         ),
-#         "type": fields.String(
-#             required=True,
-#             description="The type of suggestion. Either `State`, `County` or `Locality`",
-#             example="Locality",
-#         ),
-#         "state": fields.String(
-#             required=True,
-#             description="The state of the suggestion",
-#             example="Pennsylvania",
-#         ),
-#         "county": fields.String(
-#             required=True,
-#             description="The county of the suggestion",
-#             example="Allegheny",
-#         ),
-#         "locality": fields.String(
-#             required=True,
-#             description="The locality of the suggestion",
-#             example="Pittsburgh",
-#         ),
-#     },
-# )
-#
-# typeahead_locations_outer_model = create_outer_model(
-#     namespace_typeahead_suggestions,
-#     typeahead_suggestions_inner_model,
-#     "TypeaheadSuggestionsOuter",
-# )
-
 
 def get_typeahead_kwargs(db_client_method: Callable) -> dict:
     return {

--- a/tests/helper_scripts/helper_functions.py
+++ b/tests/helper_scripts/helper_functions.py
@@ -386,9 +386,9 @@ def setup_get_typeahead_suggestion_test_data(cursor: psycopg.Cursor):
         # Locality (via agencies table)
         cursor.execute(
             """insert into agencies 
-            (name, airtable_uid, municipality, state_iso, county_fips, county_name) 
+            (name, airtable_uid, municipality, state_iso, county_fips, county_name, jurisdiction_type) 
             values 
-            ('Xylodammerung Police Agency', 'XY_SOURCE_UID', 'Xylodammerung', 'XY', '12345', 'Arxylodon')"""
+            ('Xylodammerung Police Agency', 'XY_SOURCE_UID', 'Xylodammerung', 'XY', '12345', 'Arxylodon', 'state')"""
         )
 
         # Refresh materialized view

--- a/tests/helper_scripts/helper_functions.py
+++ b/tests/helper_scripts/helper_functions.py
@@ -392,7 +392,8 @@ def setup_get_typeahead_suggestion_test_data(cursor: psycopg.Cursor):
         )
 
         # Refresh materialized view
-        cursor.execute("CALL refresh_typeahead_suggestions();")
+        cursor.execute("CALL refresh_typeahead_agencies();")
+        cursor.execute("CALL refresh_typeahead_locations();")
     except psycopg.errors.UniqueViolation:
         cursor.execute("ROLLBACK TO SAVEPOINT typeahead_suggestion_test_savepoint")
 

--- a/tests/helper_scripts/run_and_validate_request.py
+++ b/tests/helper_scripts/run_and_validate_request.py
@@ -1,7 +1,8 @@
 from http import HTTPStatus
-from typing import Optional
+from typing import Optional, Type
 
 from flask.testing import FlaskClient
+from marshmallow import Schema
 
 from tests.helper_scripts.simple_result_validators import check_response_status
 
@@ -12,6 +13,7 @@ def run_and_validate_request(
     endpoint: str,
     expected_response_status: HTTPStatus = HTTPStatus.OK,
     expected_json_content: Optional[dict] = None,
+    expected_schema: Optional[Type[Schema]] = None,
     **request_kwargs,
 ):
     response = flask_client.open(endpoint, method=http_method, **request_kwargs)
@@ -22,6 +24,11 @@ def run_and_validate_request(
 
     # But we can also test to see if the json content is what we expect
     if expected_json_content is not None:
-        assert response.json == expected_json_content, f"Expected {expected_json_content} but got {response.json}"
+        assert (
+            response.json == expected_json_content
+        ), f"Expected {expected_json_content} but got {response.json}"
+
+    if expected_schema is not None:
+        expected_schema().load(response.json)
 
     return response.json

--- a/tests/integration/test_typeahead_suggestions.py
+++ b/tests/integration/test_typeahead_suggestions.py
@@ -8,9 +8,9 @@ from tests.helper_scripts.simple_result_validators import check_response_status
 from tests.fixtures import flask_client_with_db, dev_db_connection
 
 
-def test_typeahead_suggestions(flask_client_with_db, dev_db_connection):
+def test_typeahead_locations(flask_client_with_db, dev_db_connection):
     """
-    Test that GET call to /typeahead-suggestions endpoint successfully retrieves data
+    Test that GET call to /typeahead/locations endpoint successfully retrieves data
     """
     setup_get_typeahead_suggestion_test_data(dev_db_connection.cursor())
     dev_db_connection.commit()
@@ -41,6 +41,29 @@ def test_typeahead_suggestions(flask_client_with_db, dev_db_connection):
                     "state": "Xylonsylvania",
                     "type": "County",
                 },
+            ]
+        },
+    )
+
+def test_typeahead_agencies(flask_client_with_db, dev_db_connection):
+    """
+    Test that GET call to /typeahead/agencies endpoint successfully retrieves data
+    """
+    setup_get_typeahead_suggestion_test_data(dev_db_connection.cursor())
+    dev_db_connection.commit()
+    run_and_validate_request(
+        flask_client=flask_client_with_db,
+        http_method="get",
+        endpoint="/typeahead/agencies?query=xyl",
+        expected_json_content={
+            "suggestions": [
+                {
+                    "name": "Xylodammerung Police Agency",
+                    "municipality": "Xylodammerung",
+                    "county_name": "Arxylodon",
+                    "state_iso": "XY",
+                    "jurisdiction_type": "state",
+                }
             ]
         },
     )

--- a/tests/integration/test_typeahead_suggestions.py
+++ b/tests/integration/test_typeahead_suggestions.py
@@ -1,6 +1,7 @@
 from http import HTTPStatus
 
-from middleware.primary_resource_logic.typeahead_suggestion_logic import TypeaheadLocationsOuterResponseSchema
+from middleware.primary_resource_logic.typeahead_suggestion_logic import TypeaheadLocationsOuterResponseSchema, \
+    TypeaheadAgenciesOuterResponseSchema
 from tests.helper_scripts.helper_functions import (
     setup_get_typeahead_suggestion_test_data,
 )
@@ -44,6 +45,7 @@ def test_typeahead_locations(flask_client_with_db, dev_db_connection):
                 },
             ]
         },
+        expected_schema=TypeaheadLocationsOuterResponseSchema,
     )
 
 def test_typeahead_agencies(flask_client_with_db, dev_db_connection):
@@ -59,13 +61,13 @@ def test_typeahead_agencies(flask_client_with_db, dev_db_connection):
         expected_json_content={
             "suggestions": [
                 {
-                    "name": "Xylodammerung Police Agency",
-                    "municipality": "Xylodammerung",
+                    "display_name": "Xylodammerung Police Agency",
+                    "locality": "Xylodammerung",
                     "county": "Arxylodon",
-                    "state_iso": "XY",
+                    "state": "XY",
                     "jurisdiction_type": "state",
                 }
             ]
         },
+        expected_schema=TypeaheadAgenciesOuterResponseSchema,
     )
-    TypeaheadLocationsOuterResponseSchema().load(json_content)

--- a/tests/integration/test_typeahead_suggestions.py
+++ b/tests/integration/test_typeahead_suggestions.py
@@ -17,7 +17,7 @@ def test_typeahead_suggestions(flask_client_with_db, dev_db_connection):
     run_and_validate_request(
         flask_client=flask_client_with_db,
         http_method="get",
-        endpoint="/search/typeahead-suggestions?query=xyl",
+        endpoint="/typeahead/locations?query=xyl",
         expected_json_content={
             "suggestions": [
                 {

--- a/tests/integration/test_typeahead_suggestions.py
+++ b/tests/integration/test_typeahead_suggestions.py
@@ -1,5 +1,6 @@
 from http import HTTPStatus
 
+from middleware.primary_resource_logic.typeahead_suggestion_logic import TypeaheadLocationsOuterResponseSchema
 from tests.helper_scripts.helper_functions import (
     setup_get_typeahead_suggestion_test_data,
 )
@@ -51,7 +52,7 @@ def test_typeahead_agencies(flask_client_with_db, dev_db_connection):
     """
     setup_get_typeahead_suggestion_test_data(dev_db_connection.cursor())
     dev_db_connection.commit()
-    run_and_validate_request(
+    json_content = run_and_validate_request(
         flask_client=flask_client_with_db,
         http_method="get",
         endpoint="/typeahead/agencies?query=xyl",
@@ -60,10 +61,11 @@ def test_typeahead_agencies(flask_client_with_db, dev_db_connection):
                 {
                     "name": "Xylodammerung Police Agency",
                     "municipality": "Xylodammerung",
-                    "county_name": "Arxylodon",
+                    "county": "Arxylodon",
                     "state_iso": "XY",
                     "jurisdiction_type": "state",
                 }
             ]
         },
     )
+    TypeaheadLocationsOuterResponseSchema().load(json_content)

--- a/tests/middleware/test_typeahead_suggestion_logic.py
+++ b/tests/middleware/test_typeahead_suggestion_logic.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 from database_client.database_client import DatabaseClient
 from middleware.primary_resource_logic.typeahead_suggestion_logic import (
     get_typeahead_dict_results,
-    get_typeahead_suggestions_wrapper,
+    get_typeahead_locations_wrapper,
 )
 from tests.helper_scripts.DynamicMagicMock import DynamicMagicMock
 
@@ -71,11 +71,11 @@ def test_get_typeahead_suggestions_wrapper(monkeypatch):
         patch_root="middleware.primary_resource_logic.typeahead_suggestion_logic",
     )
 
-    get_typeahead_suggestions_wrapper(mock.db_client, mock.query)
+    get_typeahead_locations_wrapper(mock.db_client, mock.query)
 
-    mock.db_client.get_typeahead_suggestions.assert_called_with(mock.query)
+    mock.db_client.get_typeahead_locations.assert_called_with(mock.query)
     mock.get_typeahead_dict_results.assert_called_with(
-        mock.db_client.get_typeahead_suggestions.return_value
+        mock.db_client.get_typeahead_locations.return_value
     )
     mock.make_response.assert_called_with(
         {"suggestions": mock.get_typeahead_dict_results.return_value}, HTTPStatus.OK

--- a/tests/middleware/test_typeahead_suggestion_logic.py
+++ b/tests/middleware/test_typeahead_suggestion_logic.py
@@ -2,81 +2,11 @@ from http import HTTPStatus
 from unittest.mock import MagicMock
 
 from database_client.database_client import DatabaseClient
-from middleware.primary_resource_logic.typeahead_suggestion_logic import (
-    get_typeahead_dict_results,
-    get_typeahead_locations_wrapper,
-)
+
 from tests.helper_scripts.DynamicMagicMock import DynamicMagicMock
-
-
-def test_get_typeahead_dict_results():
-    mock_suggestions = [
-        DatabaseClient.TypeaheadSuggestions(
-            display_name="display_name_1",
-            type="type_1",
-            state="state_1",
-            county="county_1",
-            locality="locality_1",
-        ),
-        DatabaseClient.TypeaheadSuggestions(
-            display_name="display_name_2",
-            type="type_2",
-            state="state_2",
-            county="county_2",
-            locality="locality_2",
-        ),
-        DatabaseClient.TypeaheadSuggestions(
-            display_name="display_name_3",
-            type="type_3",
-            state="state_3",
-            county="county_3",
-            locality="locality_3",
-        ),
-    ]
-
-    expected_results = [
-        {
-            "display_name": "display_name_1",
-            "type": "type_1",
-            "state": "state_1",
-            "county": "county_1",
-            "locality": "locality_1",
-        },
-        {
-            "display_name": "display_name_2",
-            "type": "type_2",
-            "state": "state_2",
-            "county": "county_2",
-            "locality": "locality_2",
-        },
-        {
-            "display_name": "display_name_3",
-            "type": "type_3",
-            "state": "state_3",
-            "county": "county_3",
-            "locality": "locality_3",
-        },
-    ]
-
-    assert get_typeahead_dict_results(mock_suggestions) == expected_results
 
 
 class GetTypeaheadSuggestionsMocks(DynamicMagicMock):
     get_typeahead_dict_results: MagicMock
     make_response: MagicMock
 
-
-def test_get_typeahead_suggestions_wrapper(monkeypatch):
-    mock = GetTypeaheadSuggestionsMocks(
-        patch_root="middleware.primary_resource_logic.typeahead_suggestion_logic",
-    )
-
-    get_typeahead_locations_wrapper(mock.db_client, mock.query)
-
-    mock.db_client.get_typeahead_locations.assert_called_with(mock.query)
-    mock.get_typeahead_dict_results.assert_called_with(
-        mock.db_client.get_typeahead_locations.return_value
-    )
-    mock.make_response.assert_called_with(
-        {"suggestions": mock.get_typeahead_dict_results.return_value}, HTTPStatus.OK
-    )

--- a/tests/resources/test_common_format_resources.py
+++ b/tests/resources/test_common_format_resources.py
@@ -121,7 +121,7 @@ MOCK_EMAIL_PASSWORD = {
             },
         ),
         (
-            "/search/typeahead-suggestions?query=test_query",
+            "/typeahead/locations?query=test_query",
             "GET",
             "TypeaheadSuggestions.get_typeahead_suggestions_wrapper",
             {},

--- a/tests/resources/test_common_format_resources.py
+++ b/tests/resources/test_common_format_resources.py
@@ -123,7 +123,13 @@ MOCK_EMAIL_PASSWORD = {
         (
             "/typeahead/locations?query=test_query",
             "GET",
-            "TypeaheadSuggestions.get_typeahead_suggestions_wrapper",
+            "TypeaheadSuggestions.get_typeahead_results",
+            {},
+        ),
+        (
+            "typeahead/locations?query=test_query",
+            "GET",
+            "TypeaheadSuggestions.get_typeahead_results",
             {},
         ),
         (

--- a/tests/test_database_client.py
+++ b/tests/test_database_client.py
@@ -551,28 +551,28 @@ def test_get_typeahead_suggestion(live_database_client):
     setup_get_typeahead_suggestion_test_data(cursor)
 
     # Call the get_typeahead_suggestion function
-    results = live_database_client.get_typeahead_suggestions(search_term="xyl")
+    results = live_database_client.get_typeahead_locations(search_term="xyl")
 
     # Check that the results are as expected
     assert len(results) == 3
 
-    assert results[0].display_name == "Xylodammerung"
-    assert results[0].type == "Locality"
-    assert results[0].state == "Xylonsylvania"
-    assert results[0].county == "Arxylodon"
-    assert results[0].locality == "Xylodammerung"
+    assert results[0]["display_name"] == "Xylodammerung"
+    assert results[0]["type"] == "Locality"
+    assert results[0]["state"] == "Xylonsylvania"
+    assert results[0]["county"] == "Arxylodon"
+    assert results[0]["locality"] == "Xylodammerung"
 
-    assert results[1].display_name == "Xylonsylvania"
-    assert results[1].type == "State"
-    assert results[1].state == "Xylonsylvania"
-    assert results[1].county is None
-    assert results[1].locality is None
+    assert results[1]["display_name"] == "Xylonsylvania"
+    assert results[1]["type"] == "State"
+    assert results[1]["state"] == "Xylonsylvania"
+    assert results[1]["county"] is None
+    assert results[1]["locality"] is None
 
-    assert results[2].display_name == "Arxylodon"
-    assert results[2].type == "County"
-    assert results[2].state == "Xylonsylvania"
-    assert results[2].county == "Arxylodon"
-    assert results[2].locality is None
+    assert results[2]["display_name"] == "Arxylodon"
+    assert results[2]["type"] == "County"
+    assert results[2]["state"] == "Xylonsylvania"
+    assert results[2]["county"] == "Arxylodon"
+    assert results[2]["locality"] is None
 
 
 def test_search_with_location_and_record_types_real_data(live_database_client):

--- a/tests/test_database_client.py
+++ b/tests/test_database_client.py
@@ -581,11 +581,11 @@ def test_get_typeahead_agencies(live_database_client):
 
     results = live_database_client.get_typeahead_agencies(search_term="xyl")
     assert len(results) == 1
-    assert results[0]["name"] == 'Xylodammerung Police Agency'
+    assert results[0]["display_name"] == 'Xylodammerung Police Agency'
     assert results[0]["jurisdiction_type"] == "state"
-    assert results[0]["state_iso"] == "XY"
+    assert results[0]["state"] == "XY"
     assert results[0]["county"] == "Arxylodon"
-    assert results[0]["municipality"] == "Xylodammerung"
+    assert results[0]["locality"] == "Xylodammerung"
 
 def test_search_with_location_and_record_types_real_data(live_database_client):
     """

--- a/tests/test_database_client.py
+++ b/tests/test_database_client.py
@@ -545,7 +545,7 @@ def test_get_user_by_api_key(live_database_client):
     assert user_identifiers.id == user_id
 
 
-def test_get_typeahead_suggestion(live_database_client):
+def test_get_typeahead_locations(live_database_client):
     # Insert test data into the database
     cursor = live_database_client.connection.cursor()
     setup_get_typeahead_suggestion_test_data(cursor)
@@ -574,6 +574,18 @@ def test_get_typeahead_suggestion(live_database_client):
     assert results[2]["county"] == "Arxylodon"
     assert results[2]["locality"] is None
 
+def test_get_typeahead_agencies(live_database_client):
+    # Insert test data into the database
+    cursor = live_database_client.connection.cursor()
+    setup_get_typeahead_suggestion_test_data(cursor)
+
+    results = live_database_client.get_typeahead_agencies(search_term="xyl")
+    assert len(results) == 1
+    assert results[0]["name"] == 'Xylodammerung Police Agency'
+    assert results[0]["jurisdiction_type"] == "state"
+    assert results[0]["state_iso"] == "XY"
+    assert results[0]["county_name"] == "Arxylodon"
+    assert results[0]["municipality"] == "Xylodammerung"
 
 def test_search_with_location_and_record_types_real_data(live_database_client):
     """

--- a/tests/test_database_client.py
+++ b/tests/test_database_client.py
@@ -584,7 +584,7 @@ def test_get_typeahead_agencies(live_database_client):
     assert results[0]["name"] == 'Xylodammerung Police Agency'
     assert results[0]["jurisdiction_type"] == "state"
     assert results[0]["state_iso"] == "XY"
-    assert results[0]["county_name"] == "Arxylodon"
+    assert results[0]["county"] == "Arxylodon"
     assert results[0]["municipality"] == "Xylodammerung"
 
 def test_search_with_location_and_record_types_real_data(live_database_client):

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -38,7 +38,7 @@ from resources.RequestResetPassword import RequestResetPassword
 from resources.ResetPassword import ResetPassword
 from resources.ResetTokenValidation import ResetTokenValidation
 from resources.Search import Search
-from resources.TypeaheadSuggestions import TypeaheadSuggestions
+from resources.TypeaheadSuggestions import TypeaheadLocations, TypeaheadAgencies
 from resources.User import User
 from tests.fixtures import client_with_mock_db, ClientWithMockDB
 
@@ -99,7 +99,9 @@ test_parameters = [
         DataSourceById, "/data-sources/<data_source_id>", [GET, PUT, DELETE]
     ),
     TestParameters(
-        DataRequestsRelatedSources, "/data-requests/<resource_id>/related-sources", [GET]
+        DataRequestsRelatedSources,
+        "/data-requests/<resource_id>/related-sources",
+        [GET],
     ),
     TestParameters(
         DataRequestsRelatedSourcesById,
@@ -109,7 +111,7 @@ test_parameters = [
     TestParameters(AgenciesByPage, "/agencies", [POST, GET]),
     TestParameters(AgenciesById, "/agencies/<agency_id>", [GET, PUT, DELETE]),
     TestParameters(Search, "/search/search-location-and-record-type", [GET]),
-    TestParameters(TypeaheadSuggestions, "/typeahead/locations", [GET]),
+    TestParameters(TypeaheadLocations, "/typeahead/locations", [GET]),
     TestParameters(Callback, "auth/callback", [GET]),
     TestParameters(LinkToGithub, "auth/link-to-github", [POST]),
     TestParameters(LoginWithGithub, "auth/login-with-github", [POST]),
@@ -120,6 +122,7 @@ test_parameters = [
         DataRequestsById, "/data-requests/<data_request_id>", [GET, PUT, DELETE]
     ),
     TestParameters(HomepageSearchCache, "/homepage-search-cache", [GET, POST]),
+    TestParameters(TypeaheadAgencies, "/typeahead/agencies", [GET]),
 ]
 
 

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -109,7 +109,7 @@ test_parameters = [
     TestParameters(AgenciesByPage, "/agencies", [POST, GET]),
     TestParameters(AgenciesById, "/agencies/<agency_id>", [GET, PUT, DELETE]),
     TestParameters(Search, "/search/search-location-and-record-type", [GET]),
-    TestParameters(TypeaheadSuggestions, "/search/typeahead-suggestions", [GET]),
+    TestParameters(TypeaheadSuggestions, "/typeahead/locations", [GET]),
     TestParameters(Callback, "auth/callback", [GET]),
     TestParameters(LinkToGithub, "auth/link-to-github", [POST]),
     TestParameters(LoginWithGithub, "auth/login-with-github", [POST]),

--- a/utilities/namespace.py
+++ b/utilities/namespace.py
@@ -17,6 +17,7 @@ class AppNamespaces(Enum):
     DATA_SOURCES = NamespaceAttributes(
         path="data-sources", description="Data Sources Namespace"
     )
+    TYPEAHEAD = NamespaceAttributes(path="typeahead", description="Typeahead Namespace")
 
 
 def create_namespace(


### PR DESCRIPTION
### Fixes

* https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/433

### Description

* Creates new `/typeahead` namespace
* Renames `search/typeahead-suggestions/` endpoint to `/typeahead/locations`
* Implements `/typeahead/agencies/` endpoint
* Enhances documentation to incorporate Marshmallow schemas for complex objects (i.e., lists of dictionaries)

### Testing

* Run tests in `tests` directory
* Manually run `/typeahead/locations` and `/typeahead/agencies` endpoints via Swagger API to confirm functionality

### Performance

* Additional materialized view, `typeahead_agencies`, added to database, with space requirements comparable to `typeahead_locations` (formerly `typeahead_agencies`.

### Docs

* Docs updated in API swagger documentation

### Breaking Changes

* `search/typeahead-suggestions` is now `/typeahead/location`
