### PR TITLE
Mc 433 agencies typeahead

### DIFF
--- a/app.py
+++ b/app.py
@@ -29,6 +29,7 @@ from resources.RefreshSession import namespace_refresh_session
 from resources.RequestResetPassword import namespace_request_reset_password
 from resources.ResetPassword import namespace_reset_password
 from resources.ResetTokenValidation import namespace_reset_token_validation
+from resources.UniqueURLChecker import namespace_url_checker
 from resources.User import namespace_user
 from resources.CreateTestUserWithElevatedPermissions import namespace_create_test_user
 
@@ -53,7 +54,8 @@ NAMESPACES = [
     namespace_permissions,
     namespace_create_test_user,
     namespace_data_requests,
-    namespace_homepage_search_cache
+    namespace_homepage_search_cache,
+    namespace_url_checker
 ]
 
 MY_PREFIX = "/api"

--- a/database_client/constants.py
+++ b/database_client/constants.py
@@ -1,4 +1,4 @@
-from middleware.models import (
+from database_client.models import (
     Agency,
     DataRequest,
     DataSource,

--- a/database_client/database_client.py
+++ b/database_client/database_client.py
@@ -1042,5 +1042,10 @@ class DatabaseClient:
                 )
             ORDER BY COUNT_DATA_SOURCES DESC
             LIMIT 100 -- Limiting to 100 in acknowledgment of the search engine quota
-        """
-        )
+        """)
+
+    @cursor_manager()
+    def check_for_url_duplicates(self, url: str) -> list[dict]:
+        query = DynamicQueryConstructor.get_distinct_source_urls_query(url)
+        self.cursor.execute(query)
+        return self.cursor.fetchall()

--- a/database_client/database_client.py
+++ b/database_client/database_client.py
@@ -1,10 +1,7 @@
 import json
 from collections import namedtuple
-from contextlib import contextmanager
-from datetime import datetime
-from functools import wraps, partial, partialmethod
+from functools import wraps, partialmethod
 from typing import Optional, Any, List, Callable
-import uuid
 
 import psycopg
 from psycopg import sql
@@ -12,7 +9,6 @@ from psycopg.rows import dict_row, tuple_row
 from sqlalchemy import select
 from sqlalchemy.orm import aliased
 from sqlalchemy.schema import Column
-from sqlalchemy.sql.expression import UnaryExpression
 
 from database_client.constants import PAGE_SIZE, TABLE_REFERENCE
 from database_client.db_client_dataclasses import OrderByParameters, WhereMapping
@@ -24,10 +20,8 @@ from database_client.enums import (
 )
 from middleware.exceptions import (
     UserNotFoundError,
-    TokenNotFoundError,
-    AccessTokenNotFoundError,
 )
-from middleware.models import (
+from database_client.models import (
     ExternalAccount,
     User,
 )

--- a/database_client/dynamic_query_constructor.py
+++ b/database_client/dynamic_query_constructor.py
@@ -99,31 +99,6 @@ class DynamicQueryConstructor:
         return sql_query
 
     @staticmethod
-    def build_needs_identification_data_source_query():
-        data_sources_columns = DynamicQueryConstructor.create_table_columns(
-            table="data_sources", columns=DATA_SOURCES_APPROVED_COLUMNS
-        )
-        archive_info_columns = DynamicQueryConstructor.create_table_columns(
-            table="data_sources_archive_info", columns=ARCHIVE_INFO_APPROVED_COLUMNS
-        )
-        fields = DynamicQueryConstructor.build_fields(
-            columns_only=data_sources_columns,
-        )
-        sql_query = sql.SQL(
-            """
-            SELECT
-                {fields}
-            FROM
-                data_sources
-            INNER JOIN
-                data_sources_archive_info ON data_sources.airtable_uid = data_sources_archive_info.airtable_uid
-            WHERE
-                approval_status = 'needs identification'
-        """
-        ).format(fields=fields)
-        return sql_query
-
-    @staticmethod
     def zip_needs_identification_data_source_results(
         results: list[tuple],
     ) -> list[dict]:
@@ -544,3 +519,17 @@ class DynamicQueryConstructor:
             column=sql.Identifier(order_by.sort_by),
             order=sql.SQL(order_by.sort_order.value),
         )
+
+    @staticmethod
+    def get_distinct_source_urls_query(url: str) -> sql.Composed:
+        query = sql.SQL(
+            """
+            SELECT 
+                original_url,
+                rejection_note,
+                approval_status
+            FROM distinct_source_urls
+            WHERE base_url = {url}
+            """
+        ).format(url=sql.Literal(url))
+        return query

--- a/database_client/models.py
+++ b/database_client/models.py
@@ -13,7 +13,6 @@ from sqlalchemy.dialects.postgresql import ARRAY, DATE, DATERANGE, TIMESTAMP
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 from sqlalchemy.sql.expression import false, func
 
-
 ExternalAccountType = Literal["github"]
 RecordType = Literal[
     "Dispatch Recordings",
@@ -131,7 +130,7 @@ class DataRequest(Base):
     id: Mapped[int] = mapped_column(primary_key=True)
     submission_notes: Mapped[Optional[Text]] = mapped_column(Text)
     request_status: Mapped[RequestStatus] = mapped_column(
-        Enum(*get_args(RequestStatus)), name="request_status", server_defualt="Intake"
+        Enum(*get_args(RequestStatus)), name="request_status", server_default="Intake"
     )
     submitter_email: Mapped[Optional[Text]] = mapped_column(Text)
     location_described_submitted: Mapped[Optional[Text]] = mapped_column(Text)

--- a/middleware/primary_resource_logic/unique_url_checker.py
+++ b/middleware/primary_resource_logic/unique_url_checker.py
@@ -1,0 +1,75 @@
+from dataclasses import dataclass
+import re
+from marshmallow import Schema, fields, validate
+
+from database_client.enums import ApprovalStatus
+from utilities.enums import SourceMappingEnum
+
+
+def normalize_url(source_url: str) -> str:
+    # Remove 'https://', 'http://', and 'www.' from the beginning
+    url = re.sub(r"^(https://|http://|www\.)", "", source_url)
+    # Remove trailing '/'
+    url = url.rstrip("/")
+
+    return url
+
+
+class UniqueURLCheckerRequestSchema(Schema):
+    url = fields.URL(
+        required=True,
+        metadata={
+            "description": "The URL to check.",
+            "source": SourceMappingEnum.QUERY_ARGS,
+            "transformation_function": normalize_url,
+        },
+    )
+
+
+@dataclass
+class UniqueURLCheckerRequestDTO:
+    url: str
+
+
+class UniqueURLCheckerResponseInnerSchema(Schema):
+    url = fields.Str(
+        required=True,
+        metadata={
+            "description": "The URL of the duplicate.",
+            "source": SourceMappingEnum.JSON,
+        },
+    )
+    approval_status = fields.Str(
+        required=True,
+        metadata={
+            "description": "The approval status of the URL.",
+            "source": SourceMappingEnum.JSON,
+        },
+        validate=validate.OneOf([e.value for e in ApprovalStatus]),
+    )
+    rejection_note = fields.Str(
+        required=False,
+        metadata={
+            "description": "The rejection note of the URL.",
+            "source": SourceMappingEnum.JSON,
+        },
+
+    )
+
+class UniqueURLCheckerResponseOuterSchema(Schema):
+    duplicates = fields.List(
+        fields.Nested(
+            UniqueURLCheckerResponseInnerSchema,
+            required=True,
+            metadata={
+                "description": "The list of duplicate URLs.",
+                "source": SourceMappingEnum.JSON,
+            },
+        ),
+        required=True,
+        metadata={
+            "description": "The list of duplicate URLs.",
+            "source": SourceMappingEnum.JSON,
+        },
+    )
+

--- a/middleware/schema_and_dto_logic/mappings.py
+++ b/middleware/schema_and_dto_logic/mappings.py
@@ -14,6 +14,7 @@ MARSHMALLOW_TO_RESTX_FIELD_MAPPING = {
     marshmallow_fields.Email: restx_fields.String,  # Email can map to a String field in flask_restx
     marshmallow_fields.List: restx_fields.List,
     marshmallow_fields.Nested: restx_fields.Nested,
+    marshmallow_fields.URL: restx_fields.Url,
     DataField: RestxModelPlaceholder.VARIABLE_COLUMNS,
     EntryDataListField: RestxModelPlaceholder.LIST_VARIABLE_COLUMNS,
     # Add more mappings as needed
@@ -24,4 +25,5 @@ RESTX_FIELD_TO_NATIVE_TYPE_MAPPING = {
     restx_fields.Boolean: bool,
     restx_fields.List: list,
     restx_fields.Nested: dict,
+    restx_fields.Url: str,
 }

--- a/resources/UniqueURLChecker.py
+++ b/resources/UniqueURLChecker.py
@@ -1,9 +1,20 @@
+from flask import Response
+
+from middleware.access_logic import AccessInfo
 from middleware.decorators import authentication_required
 from middleware.enums import AccessTypeEnum
-from middleware.primary_resource_logic.unique_url_checker import UniqueURLCheckerRequestSchema, \
-    UniqueURLCheckerResponseOuterSchema
-from middleware.schema_and_dto_logic.dynamic_schema_documentation_construction import get_restx_param_documentation
+from middleware.primary_resource_logic.unique_url_checker import (
+    UniqueURLCheckerRequestSchema,
+    UniqueURLCheckerResponseOuterSchema,
+    unique_url_checker_wrapper,
+    UniqueURLCheckerRequestDTO,
+)
+from middleware.schema_and_dto_logic.dynamic_schema_documentation_construction import (
+    get_restx_param_documentation,
+)
+from middleware.schema_and_dto_logic.non_dto_dataclasses import SchemaPopulateParameters
 from resources.PsycopgResource import PsycopgResource, handle_exceptions
+from resources.resource_helpers import add_api_key_header_arg
 from utilities.namespace import create_namespace, AppNamespaces
 
 namespace_url_checker = create_namespace(namespace_attributes=AppNamespaces.CHECK)
@@ -17,6 +28,10 @@ response_doc_info = get_restx_param_documentation(
     namespace=namespace_url_checker,
     schema_class=UniqueURLCheckerResponseOuterSchema,
 )
+add_api_key_header_arg(
+    request_doc_info.parser
+)
+
 
 @namespace_url_checker.route("/unique-url")
 class UniqueURLChecker(PsycopgResource):
@@ -33,5 +48,11 @@ class UniqueURLChecker(PsycopgResource):
         },
         expect=[request_doc_info.parser],
     )
-    def get(self):
-        pass
+    def get(self, access_info: AccessInfo) -> Response:
+        return self.run_endpoint(
+            wrapper_function=unique_url_checker_wrapper,
+            schema_populate_parameters=SchemaPopulateParameters(
+                schema_class=UniqueURLCheckerRequestSchema,
+                dto_class=UniqueURLCheckerRequestDTO,
+            ),
+        )

--- a/resources/UniqueURLChecker.py
+++ b/resources/UniqueURLChecker.py
@@ -1,0 +1,37 @@
+from middleware.decorators import authentication_required
+from middleware.enums import AccessTypeEnum
+from middleware.primary_resource_logic.unique_url_checker import UniqueURLCheckerRequestSchema, \
+    UniqueURLCheckerResponseOuterSchema
+from middleware.schema_and_dto_logic.dynamic_schema_documentation_construction import get_restx_param_documentation
+from resources.PsycopgResource import PsycopgResource, handle_exceptions
+from utilities.namespace import create_namespace, AppNamespaces
+
+namespace_url_checker = create_namespace(namespace_attributes=AppNamespaces.CHECK)
+
+request_doc_info = get_restx_param_documentation(
+    namespace=namespace_url_checker,
+    schema_class=UniqueURLCheckerRequestSchema,
+)
+
+response_doc_info = get_restx_param_documentation(
+    namespace=namespace_url_checker,
+    schema_class=UniqueURLCheckerResponseOuterSchema,
+)
+
+@namespace_url_checker.route("/unique-url")
+class UniqueURLChecker(PsycopgResource):
+
+    @handle_exceptions
+    @authentication_required(
+        allowed_access_methods=[AccessTypeEnum.API_KEY],
+    )
+    @namespace_url_checker.doc(
+        description="Check if a URL is unique",
+        responses={
+            200: ("OK. Returns duplicate urls if they exist.", response_doc_info.model),
+            500: "Internal server error",
+        },
+        expect=[request_doc_info.parser],
+    )
+    def get(self):
+        pass

--- a/tests/helper_scripts/common_test_data.py
+++ b/tests/helper_scripts/common_test_data.py
@@ -65,3 +65,27 @@ def create_agency_entry_for_search_cache(db_client: DatabaseClient) -> str:
         },
     )
     return submitted_name
+
+
+def create_data_source_entry_for_url_duplicate_checking(db_client: DatabaseClient) -> str:
+    """
+    Create an entry in `Data Sources` guaranteed to appear in the URL duplicate checking functionality
+    :param db_client:
+    :return:
+    """
+    submitted_name = "TEST URL DUPLICATE NAME"
+    try:
+        db_client._create_entry_in_table(
+            table_name="data_sources",
+            column_value_mappings={
+                "submitted_name": submitted_name,
+                "name": submitted_name,
+                "airtable_uid": "TEST_URL_DUPLICATE_SOURCE_ID",
+                "source_url": "https://duplicate-checker.com/",
+
+            })
+        db_client.execute_raw_sql("""
+            call refresh_distinct_source_urls();
+        """)
+    except psycopg.errors.UniqueViolation:
+        pass  # Already added

--- a/tests/helper_scripts/common_test_data.py
+++ b/tests/helper_scripts/common_test_data.py
@@ -89,3 +89,6 @@ def create_data_source_entry_for_url_duplicate_checking(db_client: DatabaseClien
         """)
     except psycopg.errors.UniqueViolation:
         pass  # Already added
+    except Exception as e:
+        # Rollback
+        db_client.connection.rollback()

--- a/tests/helper_scripts/common_test_data.py
+++ b/tests/helper_scripts/common_test_data.py
@@ -80,6 +80,8 @@ def create_data_source_entry_for_url_duplicate_checking(db_client: DatabaseClien
             column_value_mappings={
                 "submitted_name": submitted_name,
                 "name": submitted_name,
+                "rejection_note": "Test rejection note",
+                "approval_status": "rejected",
                 "airtable_uid": "TEST_URL_DUPLICATE_SOURCE_ID",
                 "source_url": "https://duplicate-checker.com/",
 

--- a/tests/helper_scripts/run_and_validate_request.py
+++ b/tests/helper_scripts/run_and_validate_request.py
@@ -4,6 +4,7 @@ from typing import Optional, Type
 from flask.testing import FlaskClient
 from marshmallow import Schema
 
+from tests.helper_scripts.helper_functions import add_query_params
 from tests.helper_scripts.simple_result_validators import check_response_status
 
 
@@ -14,8 +15,24 @@ def run_and_validate_request(
     expected_response_status: HTTPStatus = HTTPStatus.OK,
     expected_json_content: Optional[dict] = None,
     expected_schema: Optional[Type[Schema]] = None,
+    query_parameters: Optional[dict] = None,
     **request_kwargs,
 ):
+    """
+    Run a request and validate the response.
+    :param flask_client: The flask test client
+    :param http_method: The http method to use
+    :param endpoint: The endpoint to send the request to
+    :param expected_response_status: The expected status code of the response
+    :param expected_json_content: The expected json content of the response
+    :param expected_schema: An optional Marshmallow schema to validate the response against
+    :param query_parameters: Query parameters, if any, to add to the endpoint
+    :param request_kwargs: Additional keyword arguments to add to the request
+    :return: The json content of the response
+    """
+    if query_parameters is not None:
+        endpoint = add_query_params(endpoint, query_parameters)
+
     response = flask_client.open(endpoint, method=http_method, **request_kwargs)
     check_response_status(response, expected_response_status.value)
 
@@ -24,9 +41,10 @@ def run_and_validate_request(
 
     # But we can also test to see if the json content is what we expect
     if expected_json_content is not None:
-        assert (
-            response.json == expected_json_content
-        ), f"Expected {expected_json_content} but got {response.json}"
+        try:
+            assert response.json == expected_json_content
+        except AssertionError:
+            raise AssertionError(f"Expected {expected_json_content} but got {response.json}")
 
     if expected_schema is not None:
         expected_schema().load(response.json)

--- a/tests/integration/test_unique_url_checker.py
+++ b/tests/integration/test_unique_url_checker.py
@@ -1,0 +1,57 @@
+from database_client.database_client import DatabaseClient
+from middleware.primary_resource_logic.unique_url_checker import (
+    UniqueURLCheckerResponseOuterSchema,
+)
+from tests.fixtures import flask_client_with_db, live_database_client, integration_test_admin_setup
+from tests.helper_scripts.common_test_data import (
+    create_data_source_entry_for_url_duplicate_checking,
+)
+from tests.helper_scripts.run_and_validate_request import run_and_validate_request
+
+
+
+def test_unique_url_checker(
+        flask_client_with_db,
+        live_database_client,
+        integration_test_admin_setup
+):
+    ENDPOINT = "check/unique-url"
+    header = integration_test_admin_setup.tus.api_authorization_header
+    create_data_source_entry_for_url_duplicate_checking(live_database_client)
+
+    # Happy path
+    non_duplicate_url = "https://not-a-duplicate.com"
+    run_and_validate_request(
+        flask_client=flask_client_with_db,
+        http_method="get",
+        endpoint=ENDPOINT,
+        query_parameters={"url": non_duplicate_url},
+        expected_json_content={"duplicates": []},
+        expected_schema=UniqueURLCheckerResponseOuterSchema,
+        headers=header
+    )
+
+    # Add tests for multiple variants
+    same_urls = [
+        "http://duplicate-checker.com/",
+        "https://www.duplicate-checker.com",
+        "http://www.duplicate-checker.com/",
+    ]
+    for url in same_urls:
+        run_and_validate_request(
+            flask_client=flask_client_with_db,
+            http_method="get",
+            endpoint=ENDPOINT,
+            query_parameters={"url": url},
+            expected_json_content={
+                "duplicates": [
+                    {
+                        "original_url": "https://duplicate-checker.com/",
+                        "approval_status": "rejected",
+                        "rejection_note": "Test rejection note",
+                    }
+                ]
+            },
+            expected_schema=UniqueURLCheckerResponseOuterSchema,
+            headers=header
+        )

--- a/tests/middleware/test_unique_url_checker.py
+++ b/tests/middleware/test_unique_url_checker.py
@@ -1,0 +1,17 @@
+import pytest
+
+from middleware.primary_resource_logic.unique_url_checker import normalize_url
+
+
+@pytest.mark.parametrize(
+    "url",
+    (
+        "http://duplicate-checker.com/",
+        "https://www.duplicate-checker.com",
+        "http://www.duplicate-checker.com/",
+    ),
+)
+def test_normalize_url(url):
+    expected_url = "duplicate-checker.com"
+
+    assert normalize_url(url) == expected_url

--- a/tests/resources/test_common_format_resources.py
+++ b/tests/resources/test_common_format_resources.py
@@ -227,6 +227,7 @@ MOCK_EMAIL_PASSWORD = {
             },
         ),
         ("/agencies/test_id", "DELETE", "Agencies.delete_agency", {}),
+        ("/check/unique-url?url=test_url", "GET", "UniqueURLChecker.check_unique_url", {}),
     ),
 )
 def test_common_format_resources(

--- a/tests/resources/test_common_format_resources.py
+++ b/tests/resources/test_common_format_resources.py
@@ -21,6 +21,7 @@ from tests.helper_scripts.DynamicMagicMock import DynamicMagicMock
 from tests.helper_scripts.common_test_data import TEST_RESPONSE
 from tests.helper_scripts.helper_functions import (
     check_is_test_response,
+    add_query_params,
 )
 from tests.helper_scripts.run_and_validate_request import run_and_validate_request
 
@@ -35,6 +36,7 @@ MOCK_EMAIL_PASSWORD = {
     "password": "test_password",
 }
 TEST_ID = -1
+
 
 @pytest.mark.parametrize(
     "endpoint, http_method, route_to_patch, json_data",
@@ -64,7 +66,12 @@ TEST_ID = -1
             {"entry_data": {}},
         ),
         ("/data-sources?page=1", "GET", "DataSources.get_data_sources_wrapper", {}),
-        ("/data-requests/test_id/related-sources", "GET", "DataRequests.get_data_request_related_sources", {}),
+        (
+            "/data-requests/test_id/related-sources",
+            "GET",
+            "DataRequests.get_data_request_related_sources",
+            {},
+        ),
         # This endpoint no longer works because of the other data source endpoint
         # It is interpreted as another data source id
         # But we have not yet decided whether to modify or remove it entirely
@@ -227,7 +234,15 @@ TEST_ID = -1
             },
         ),
         (f"/agencies/{TEST_ID}", "DELETE", "Agencies.delete_agency", {}),
-        ("/check/unique-url?url=test_url", "GET", "UniqueURLChecker.check_unique_url", {}),
+        (
+            add_query_params(
+                url="/check/unique-url",
+                params={"url": "https://www.test-url.com"}
+            ),
+            "GET",
+            "UniqueURLChecker.unique_url_checker_wrapper",
+            {},
+        ),
     ),
 )
 def test_common_format_resources(

--- a/tests/test_database_client.py
+++ b/tests/test_database_client.py
@@ -930,10 +930,28 @@ def test_check_for_url_duplicates(live_database_client):
     create_data_source_entry_for_url_duplicate_checking(live_database_client)
 
     # Happy path
-    url = "https://duplicate-checker.com/"
-    results = live_database_client.check_for_url_duplicates(url)
+    non_duplicate_url = "not-a-duplicate.com"
+    results = live_database_client.check_for_url_duplicates(non_duplicate_url)
+    assert len(results) == 0
 
-    # Add tests for multiple variants
+    duplicate_base_url = "duplicate-checker.com"
+    results = live_database_client.check_for_url_duplicates(duplicate_base_url)
+    assert len(results) == 1
+    #
+    #
+    # # Add tests for multiple variants
+    # # TODO: Add multiple variants test to a unit test for the url transformation function,
+    # #    OR for the integration test
+    # same_urls = [
+    #     "http://duplicate-checker.com/",
+    #     "https://www.duplicate-checker.com",
+    #     "http://www.duplicate-checker.com/",
+    # ]
+    #
+    # for url in same_urls:
+    #     results = live_database_client.check_for_url_duplicates(url)
+    #     assert len(results) == 1
+
 
 
 # TODO: This code currently doesn't work properly because it will repeatedly insert the same test data, throwing off counts

--- a/tests/test_database_client.py
+++ b/tests/test_database_client.py
@@ -18,11 +18,10 @@ from database_client.enums import (
     ColumnPermissionEnum,
     SortOrder,
 )
-from database_client.result_formatter import ResultFormatter
 from middleware.exceptions import (
     UserNotFoundError,
 )
-from middleware.models import ExternalAccount, TestTable, User
+from database_client.models import ExternalAccount, TestTable, User
 from middleware.enums import PermissionsEnum
 from tests.fixtures import (
     live_database_client,

--- a/tests/test_database_client.py
+++ b/tests/test_database_client.py
@@ -29,6 +29,7 @@ from tests.fixtures import (
 from tests.helper_scripts.common_test_data import (
     insert_test_column_permission_data,
     create_agency_entry_for_search_cache,
+    create_data_source_entry_for_url_duplicate_checking,
 )
 from tests.helper_scripts.helper_functions import (
     insert_test_agencies_and_sources_if_not_exist,
@@ -574,6 +575,7 @@ def test_get_typeahead_locations(live_database_client):
     assert results[2]["county"] == "Arxylodon"
     assert results[2]["locality"] is None
 
+
 def test_get_typeahead_agencies(live_database_client):
     # Insert test data into the database
     cursor = live_database_client.connection.cursor()
@@ -581,11 +583,12 @@ def test_get_typeahead_agencies(live_database_client):
 
     results = live_database_client.get_typeahead_agencies(search_term="xyl")
     assert len(results) == 1
-    assert results[0]["display_name"] == 'Xylodammerung Police Agency'
+    assert results[0]["display_name"] == "Xylodammerung Police Agency"
     assert results[0]["jurisdiction_type"] == "state"
     assert results[0]["state"] == "XY"
     assert results[0]["county"] == "Arxylodon"
     assert results[0]["locality"] == "Xylodammerung"
+
 
 def test_search_with_location_and_record_types_real_data(live_database_client):
     """
@@ -893,6 +896,7 @@ def test_get_related_data_sources(live_database_client):
             source["name"] for source in source_column_value_mappings
         ]
 
+
 def test_create_request_source_relation(live_database_client):
     # Create data source and request
 
@@ -916,6 +920,17 @@ def test_create_request_source_relation(live_database_client):
         live_database_client.create_request_source_relation(
             column_value_mappings={"request_id": request_id, "source_id": source_id}
         )
+
+
+def test_check_for_url_duplicates(live_database_client):
+
+    create_data_source_entry_for_url_duplicate_checking(live_database_client)
+
+    # Happy path
+    url = "https://duplicate-checker.com/"
+    results = live_database_client.check_for_url_duplicates(url)
+
+    # Add tests for multiple variants
 
 
 # TODO: This code currently doesn't work properly because it will repeatedly insert the same test data, throwing off counts

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -39,6 +39,7 @@ from resources.ResetPassword import ResetPassword
 from resources.ResetTokenValidation import ResetTokenValidation
 from resources.Search import Search
 from resources.TypeaheadSuggestions import TypeaheadLocations, TypeaheadAgencies
+from resources.UniqueURLChecker import UniqueURLChecker
 from resources.User import User
 from tests.fixtures import client_with_mock_db, ClientWithMockDB
 
@@ -123,6 +124,7 @@ test_parameters = [
     ),
     TestParameters(HomepageSearchCache, "/homepage-search-cache", [GET, POST]),
     TestParameters(TypeaheadAgencies, "/typeahead/agencies", [GET]),
+    TestParameters(UniqueURLChecker, "/check/unique-url", [GET]),
 ]
 
 

--- a/utilities/namespace.py
+++ b/utilities/namespace.py
@@ -18,6 +18,7 @@ class AppNamespaces(Enum):
         path="data-sources", description="Data Sources Namespace"
     )
     TYPEAHEAD = NamespaceAttributes(path="typeahead", description="Typeahead Namespace")
+    CHECK = NamespaceAttributes(path="check", description="Check Namespace")
 
 
 def create_namespace(


### PR DESCRIPTION
### Fixes

* https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/434

### Description

* Add url checker endpoint `/check/duplicate-urls` with attendant logic and documentation.
* LIBTYFI: A few small quality-of-code improvements to the latest SQL Alchemy update. Moved `models.py` to the `database_client` directory, corrected a small typo.

### Testing

* Run tests in `tests` directory
* Manually utilize new `/check/duplicate-urls` endpoint to confirm functionality

### Performance

* New materialized view added for duplicate urls.
* Performance impact otherwise marginal.

### Docs

* New documentation added in API.

### Breaking Changes

* Not applicable.