### PR TITLE
Fix bug and documentation

### DIFF
--- a/middleware/primary_resource_logic/data_source_queries.py
+++ b/middleware/primary_resource_logic/data_source_queries.py
@@ -27,6 +27,7 @@ from middleware.schema_and_dto_logic.common_schemas_and_dtos import (
     GetByIDBaseDTO,
 )
 from middleware.common_response_formatting import format_list_response
+from utilities.common import match_string_to_enum
 from utilities.enums import SourceMappingEnum
 
 RELATION = Relations.DATA_SOURCES.value
@@ -37,12 +38,13 @@ class DataSourceNotFoundError(Exception):
 
 
 class DataSourcesGetRequestSchemaMany(GetManyBaseSchema):
-    approval_status = fields.Str(
+    approval_status = fields.Enum(
+        enum=ApprovalStatus,
+        by_value=fields.String,
         required=False,
-        validate=validate.OneOf([e.value for e in ApprovalStatus]),
         metadata={
             "source": SourceMappingEnum.QUERY_ARGS,
-            "description": "The approval status of the data sources",
+            "description": "The approval status of the data sources.",
             "default": "approved",
         }
     )

--- a/middleware/primary_resource_logic/unique_url_checker.py
+++ b/middleware/primary_resource_logic/unique_url_checker.py
@@ -45,13 +45,14 @@ class UniqueURLCheckerResponseInnerSchema(Schema):
             "source": SourceMappingEnum.JSON,
         },
     )
-    approval_status = fields.Str(
+    approval_status = fields.Enum(
         required=True,
+        enum=ApprovalStatus,
+        by_value=fields.Str,
         metadata={
             "description": "The approval status of the URL.",
             "source": SourceMappingEnum.JSON,
         },
-        validate=validate.OneOf([e.value for e in ApprovalStatus]),
     )
     rejection_note = fields.Str(
         required=False,

--- a/middleware/schema_and_dto_logic/common_schemas_and_dtos.py
+++ b/middleware/schema_and_dto_logic/common_schemas_and_dtos.py
@@ -33,11 +33,11 @@ class GetManyBaseSchema(Schema):
             "source": SourceMappingEnum.QUERY_ARGS
         }
     )
-    sort_order = fields.Str(
+    sort_order = fields.Enum(
         required=False,
-        validate=validate.OneOf([e.value for e in SortOrder]),
+        enum=SortOrder,
+        by_value=fields.Str,
         metadata={
-            "transformation_function": lambda value: get_valid_enum_value(SortOrder, value),
             "source": SourceMappingEnum.QUERY_ARGS,
             "description": "The order to sort the results by.",
         }

--- a/middleware/schema_and_dto_logic/dynamic_schema_documentation_construction.py
+++ b/middleware/schema_and_dto_logic/dynamic_schema_documentation_construction.py
@@ -73,6 +73,12 @@ def add_description_info_from_validators(
 
 
 # region Classes
+def add_description_info_from_enum(field_value: marshmallow_fields.Enum, description: str):
+    enum_class = field_value.enum
+    description += f" Must be one of: {[x.value for x in enum_class]}."
+    return description
+
+
 class FieldInfo:
 
     def __init__(
@@ -100,6 +106,8 @@ class FieldInfo:
         field_value: marshmallow_fields,
     ) -> str:
         description = _get_required_argument("description", metadata, schema_class)
+        if isinstance(field_value, marshmallow_fields.Enum):
+            description = add_description_info_from_enum(field_value, description)
         return add_description_info_from_validators(field_value, description)
 
     def _map_field_type(self, field_type: type[MarshmallowFields]) -> Type[RestxFields]:

--- a/middleware/schema_and_dto_logic/mappings.py
+++ b/middleware/schema_and_dto_logic/mappings.py
@@ -15,6 +15,7 @@ MARSHMALLOW_TO_RESTX_FIELD_MAPPING = {
     marshmallow_fields.List: restx_fields.List,
     marshmallow_fields.Nested: restx_fields.Nested,
     marshmallow_fields.URL: restx_fields.Url,
+    marshmallow_fields.Enum: restx_fields.String,
     DataField: RestxModelPlaceholder.VARIABLE_COLUMNS,
     EntryDataListField: RestxModelPlaceholder.LIST_VARIABLE_COLUMNS,
     # Add more mappings as needed

--- a/tests/integration/test_data_sources.py
+++ b/tests/integration/test_data_sources.py
@@ -36,7 +36,7 @@ def test_data_sources_get(
     response_json = run_and_validate_request(
         flask_client=flask_client_with_db,
         http_method="get",
-        endpoint=f"{DATA_SOURCES_BASE_ENDPOINT}?page=1",  # ENDPOINT,
+        endpoint=f"{DATA_SOURCES_BASE_ENDPOINT}?page=1&approval_status=approved",  # ENDPOINT,
         headers=tus.api_authorization_header,
     )
     data = response_json["data"]

--- a/tests/resources/test_common_format_resources.py
+++ b/tests/resources/test_common_format_resources.py
@@ -65,7 +65,7 @@ TEST_ID = -1
             "DataSources.add_new_data_source_wrapper",
             {"entry_data": {}},
         ),
-        ("/data-sources?page=1", "GET", "DataSources.get_data_sources_wrapper", {}),
+        ("/data-sources?page=1&approval_status=approved", "GET", "DataSources.get_data_sources_wrapper", {}),
         (
             "/data-requests/test_id/related-sources",
             "GET",


### PR DESCRIPTION
### Fixes

* https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/441

### Description

* Fix bug causing a passed valid `approval_status` query parameter to error out.
* Fix documentation for `/data-sources`, and `/data-sources/{id}`, where `GET` method erroneously listed only API key Authorization as allowed, when in fact JWT is also allowed. 
* LIBTYFI: Add `Enum` schema validation logic (and description enhancement) to Dynamic Marshmallow-to-Restx Schema construction, as well as select schemas

### Testing

* Run tests in `tests` directory to confirm functionality
* Inspect `/data-sources` endpoint to ensure `Authorization` headers appear as expected. 

### Performance

* Performance impact marginal.

### Docs

* `/data-sources` endpoint documentation added as described above.

### Breaking Changes

* Not applicable. 

