### PR TITLE
Shorten request urgency enum

### DIFF
--- a/database_client/enums.py
+++ b/database_client/enums.py
@@ -148,8 +148,8 @@ class RequestUrgency(Enum):
     Correlates to the request_urgency enum in the database
     """
 
-    URGENT = "Urgent (Less than a week)"
-    SOMEWHAT_URGENT = "Somewhat urgent (Less than a month)"
-    NOT_URGENT = "Not urgent (A few months)"
-    LONG_TERM = "Long-term (6 months or more)"
-    INDEFINITE = "Indefinite/Unknown"
+    URGENT = "urgent"  # Less than a week
+    SOMEWHAT_URGENT = "somewhat_urgent"  # Less than a month
+    NOT_URGENT = "not_urgent"  # A few months
+    LONG_TERM = "long_term"  # A year or more
+    INDEFINITE = "indefinite_unknown"  # Indefinite or unknown length of time

--- a/database_client/models.py
+++ b/database_client/models.py
@@ -111,11 +111,11 @@ DetailLevelLiteral = Literal[
 AccessTypeLiteral = Literal["Web page", "API", "Download"]
 UpdateMethodLiteral = Literal["Insert", "No updates", "Overwrite"]
 RequestUrgencyLiteral = Literal[
-    "Urgent (Less than a week)",
-    "Somewhat urgent (Less than a month)",
-    "Not urgent (A few months)",
-    "Long-term (6 months or more)",
-    "Indefinite/Unknown",
+    "urgent",
+    "somewhat_urgent",
+    "not_urgent",
+    "long_term",
+    "indefinite_unknown",
 ]
 LocationTypeLiteral = Literal[
     "State",


### PR DESCRIPTION
#### Fixes

* https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/486

#### Description

* Shortens `request_urgency` enums to single words or two-word snake-cased phrases

#### Testing

* Run tests in `/tests` to confirm functionality

#### Performance

* Performance impact marginal 

#### Docs

* API documentation updated.

#### Breaking Changes

* None at this time. 