### PR TITLE
Mc 388 encrypt api keys

### DIFF
--- a/app.py
+++ b/app.py
@@ -23,7 +23,7 @@ from flask_restx import Api
 from config import config, oauth, limiter, jwt
 from middleware.initialize_psycopg_connection import initialize_psycopg_connection
 from resources.Agencies import namespace_agencies
-from resources.ApiKey import namespace_api_key
+from resources.ApiKeyResource import namespace_api_key
 from resources.Archives import namespace_archives
 from resources.DataSources import namespace_data_source
 from resources.Login import namespace_login

--- a/middleware/access_logic.py
+++ b/middleware/access_logic.py
@@ -6,6 +6,7 @@ from flask import request
 from flask_jwt_extended import get_jwt_identity, verify_jwt_in_request
 from flask_restx import abort
 
+from middleware.api_key import ApiKey
 from middleware.enums import PermissionsEnum, AccessTypeEnum
 from database_client.helper_functions import get_db_client
 from middleware.exceptions import (
@@ -76,12 +77,13 @@ def get_jwt_access_info_with_permissions(user_email):
 
 def get_user_email_from_api_key() -> Optional[str]:
     try:
-        api_key = get_api_key_from_request_header()
+        raw_key = get_api_key_from_request_header()
     except (InvalidAPIKeyException, InvalidAuthorizationHeaderException):
         return None
 
+    api_key = ApiKey(raw_key=raw_key)
     db_client = get_db_client()
-    user_identifiers = db_client.get_user_by_api_key(api_key)
+    user_identifiers = db_client.get_user_by_api_key(api_key.key_hash)
     return user_identifiers.email
 
 

--- a/middleware/api_key.py
+++ b/middleware/api_key.py
@@ -1,0 +1,19 @@
+import hashlib
+import uuid
+from typing import Optional
+
+
+class ApiKey:
+    def __init__(self, raw_key: Optional[str] = None):
+        if raw_key is None:
+            raw_key = self.generate_api_key()
+        self.raw_key = raw_key
+        self.key_hash = self.hash_api_key(self.raw_key)
+
+    @staticmethod
+    def generate_api_key():
+        return uuid.uuid4().hex
+
+    @staticmethod
+    def hash_api_key(raw_key: str):
+        return hashlib.sha256(raw_key.encode()).hexdigest()

--- a/middleware/decorators.py
+++ b/middleware/decorators.py
@@ -13,7 +13,8 @@ from middleware.schema_and_dto_logic.dynamic_logic.dynamic_schema_documentation_
     get_restx_param_documentation,
 )
 from middleware.schema_and_dto_logic.non_dto_dataclasses import FlaskRestxDocInfo
-from middleware.security import check_api_key, check_permissions
+from middleware.security import check_permissions
+from middleware.primary_resource_logic.api_key_logic import check_api_key
 from resources.PsycopgResource import handle_exceptions
 from resources.resource_helpers import (
     add_jwt_or_api_key_header_arg,

--- a/middleware/primary_resource_logic/api_key_logic.py
+++ b/middleware/primary_resource_logic/api_key_logic.py
@@ -8,12 +8,16 @@ from werkzeug.security import check_password_hash
 from database_client.database_client import DatabaseClient
 from database_client.helper_functions import get_db_client
 from middleware.access_logic import get_api_key_from_request_header
+from middleware.api_key import ApiKey
 from middleware.exceptions import InvalidAPIKeyException, InvalidAuthorizationHeaderException
 from middleware.primary_resource_logic.user_queries import UserRequestDTO
-
+import hashlib
 
 def generate_api_key() -> str:
     return uuid.uuid4().hex
+
+def hash_api_key(api_key: str) -> str:
+    return hashlib.sha256(api_key.encode()).hexdigest()
 
 
 def create_api_key_for_user(db_client: DatabaseClient, dto: UserRequestDTO) -> Response:
@@ -28,18 +32,18 @@ def create_api_key_for_user(db_client: DatabaseClient, dto: UserRequestDTO) -> R
     user_data = db_client.get_user_info(dto.email)
 
     if check_password_hash(user_data.password_digest, dto.password):
-        api_key = generate_api_key()
-        db_client.update_user_api_key(user_id=user_data.id, api_key=api_key)
-        payload = {"api_key": api_key}
+        api_key = ApiKey()
+        db_client.update_user_api_key(user_id=user_data.id, api_key=api_key.key_hash)
+        payload = {"api_key": api_key.raw_key}
         return make_response(payload, HTTPStatus.OK)
 
     return make_response(
         {"message": "Invalid email or password"}, HTTPStatus.UNAUTHORIZED
     )
 
-
-def check_api_key_associated_with_user(db_client: DatabaseClient, api_key: str) -> None:
-    user_identifiers = db_client.get_user_by_api_key(api_key)
+def check_api_key_associated_with_user(db_client: DatabaseClient, raw_key: str) -> None:
+    api_key = ApiKey(raw_key)
+    user_identifiers = db_client.get_user_by_api_key(api_key.key_hash)
     if user_identifiers is None:
         abort(HTTPStatus.UNAUTHORIZED, "Invalid API Key")
 

--- a/middleware/primary_resource_logic/login_queries.py
+++ b/middleware/primary_resource_logic/login_queries.py
@@ -1,4 +1,3 @@
-import uuid
 from http import HTTPStatus
 
 from flask import Response, make_response, jsonify
@@ -56,32 +55,6 @@ def login_response(
             refresh_token=refresh_token,
         ),
         HTTPStatus.OK,
-    )
-
-
-def generate_api_key() -> str:
-    return uuid.uuid4().hex
-
-
-def create_api_key_for_user(db_client: DatabaseClient, dto: UserRequestDTO) -> Response:
-    """
-    Tries to log in a user. If successful, generates API key
-
-    :param db_client: A DatabaseClient object.
-    :param email: User's email.
-    :param password: User's password.
-    :return: A response object with a message and status code.
-    """
-    user_data = db_client.get_user_info(dto.email)
-
-    if check_password_hash(user_data.password_digest, dto.password):
-        api_key = generate_api_key()
-        db_client.update_user_api_key(user_id=user_data.id, api_key=api_key)
-        payload = {"api_key": api_key}
-        return make_response(payload, HTTPStatus.OK)
-
-    return make_response(
-        {"message": "Invalid email or password"}, HTTPStatus.UNAUTHORIZED
     )
 
 

--- a/middleware/primary_resource_logic/login_queries.py
+++ b/middleware/primary_resource_logic/login_queries.py
@@ -63,7 +63,7 @@ def generate_api_key() -> str:
     return uuid.uuid4().hex
 
 
-def get_api_key_for_user(db_client: DatabaseClient, dto: UserRequestDTO) -> Response:
+def create_api_key_for_user(db_client: DatabaseClient, dto: UserRequestDTO) -> Response:
     """
     Tries to log in a user. If successful, generates API key
 

--- a/middleware/primary_resource_logic/reset_token_queries.py
+++ b/middleware/primary_resource_logic/reset_token_queries.py
@@ -9,7 +9,7 @@ from werkzeug.security import generate_password_hash
 
 from database_client.database_client import DatabaseClient
 from middleware.flask_response_manager import FlaskResponseManager
-from middleware.primary_resource_logic.login_queries import generate_api_key
+from middleware.primary_resource_logic.api_key_logic import generate_api_key
 from middleware.primary_resource_logic.user_queries import user_check_email
 from middleware.webhook_logic import send_password_reset_link
 from utilities.enums import SourceMappingEnum

--- a/middleware/security.py
+++ b/middleware/security.py
@@ -2,34 +2,9 @@ from http import HTTPStatus
 from flask_jwt_extended import get_jwt_identity, verify_jwt_in_request
 from flask_restx import abort
 
-from database_client.database_client import DatabaseClient
 from database_client.helper_functions import get_db_client
-from middleware.access_logic import (
-    get_api_key_from_request_header,
-)
-from middleware.exceptions import (
-    InvalidAPIKeyException,
-    InvalidAuthorizationHeaderException,
-)
 from middleware.enums import PermissionsEnum
 from middleware.primary_resource_logic.permissions_logic import PermissionsManager
-
-INVALID_API_KEY_MESSAGE = "Please provide an API key in the request header in the 'Authorization' key with the format 'Basic <api_key>'"
-
-
-def check_api_key_associated_with_user(db_client: DatabaseClient, api_key: str) -> None:
-    user_identifiers = db_client.get_user_by_api_key(api_key)
-    if user_identifiers is None:
-        abort(HTTPStatus.UNAUTHORIZED, "Invalid API Key")
-
-
-def check_api_key() -> None:
-    try:
-        api_key = get_api_key_from_request_header()
-        db_client = get_db_client()
-        check_api_key_associated_with_user(db_client, api_key)
-    except (InvalidAPIKeyException, InvalidAuthorizationHeaderException):
-        abort(code=HTTPStatus.UNAUTHORIZED, message=INVALID_API_KEY_MESSAGE)
 
 
 def check_permissions(permission: PermissionsEnum) -> None:

--- a/resources/ApiKey.py
+++ b/resources/ApiKey.py
@@ -1,7 +1,7 @@
 from flask import Response
 from flask_restx import fields
 
-from middleware.primary_resource_logic.login_queries import get_api_key_for_user
+from middleware.primary_resource_logic.login_queries import create_api_key_for_user
 from middleware.primary_resource_logic.user_queries import UserRequestDTO
 from middleware.schema_and_dto_logic.dynamic_logic.model_helpers_with_schemas import (
     create_user_model,
@@ -58,7 +58,7 @@ class ApiKey(PsycopgResource):
         - dict: A dictionary containing the generated API key, or None if an error occurs.
         """
         return self.run_endpoint(
-            wrapper_function=get_api_key_for_user,
+            wrapper_function=create_api_key_for_user,
             dto_populate_parameters=DTOPopulateParameters(
                 source=SourceMappingEnum.JSON,
                 dto_class=UserRequestDTO,

--- a/resources/ApiKey.py
+++ b/resources/ApiKey.py
@@ -1,7 +1,7 @@
 from flask import Response
 from flask_restx import fields
 
-from middleware.primary_resource_logic.login_queries import create_api_key_for_user
+from middleware.primary_resource_logic.api_key_logic import create_api_key_for_user
 from middleware.primary_resource_logic.user_queries import UserRequestDTO
 from middleware.schema_and_dto_logic.dynamic_logic.model_helpers_with_schemas import (
     create_user_model,

--- a/resources/ApiKeyResource.py
+++ b/resources/ApiKeyResource.py
@@ -40,7 +40,7 @@ API_KEY_ROUTE = "/api-key"
         500: "Internal server error.",
     },
 )
-class ApiKey(PsycopgResource):
+class ApiKeyResource(PsycopgResource):
     """Represents a resource for generating an API key for authenticated users."""
 
     @handle_exceptions

--- a/resources/CreateTestUserWithElevatedPermissions.py
+++ b/resources/CreateTestUserWithElevatedPermissions.py
@@ -18,7 +18,7 @@ from flask import request
 from flask_restx import fields, abort
 
 from middleware.enums import PermissionsEnum
-from middleware.primary_resource_logic.login_queries import create_api_key_for_user
+from middleware.primary_resource_logic.api_key_logic import create_api_key_for_user
 from middleware.primary_resource_logic.user_queries import (
     user_post_results,
     UserRequestDTO,

--- a/resources/CreateTestUserWithElevatedPermissions.py
+++ b/resources/CreateTestUserWithElevatedPermissions.py
@@ -18,7 +18,7 @@ from flask import request
 from flask_restx import fields, abort
 
 from middleware.enums import PermissionsEnum
-from middleware.primary_resource_logic.login_queries import get_api_key_for_user
+from middleware.primary_resource_logic.login_queries import create_api_key_for_user
 from middleware.primary_resource_logic.user_queries import (
     user_post_results,
     UserRequestDTO,
@@ -101,7 +101,7 @@ class CreateTestUserWithElevatedPermissions(PsycopgResource):
                     user_email=auto_user_email,
                     permission=permission,
                 )
-            api_key = get_api_key_for_user(db_client=db_client, dto=dto).json["api_key"]
+            api_key = create_api_key_for_user(db_client=db_client, dto=dto).json["api_key"]
         return {
             "email": auto_user_email,
             "password": auto_user_password,

--- a/tests/helper_scripts/helper_functions.py
+++ b/tests/helper_scripts/helper_functions.py
@@ -25,7 +25,7 @@ from middleware.enums import (
     Relations,
     JurisdictionType,
 )
-from resources.ApiKey import API_KEY_ROUTE
+from resources.ApiKeyResource import API_KEY_ROUTE
 from tests.helper_scripts.constants import TEST_RESPONSE
 from tests.helper_scripts.simple_result_validators import check_response_status
 from tests.helper_scripts.helper_classes.TestUserSetup import TestUserSetup

--- a/tests/integration/test_agencies.py
+++ b/tests/integration/test_agencies.py
@@ -24,7 +24,7 @@ from tests.conftest import (
     flask_client_with_db,
     integration_test_admin_setup,
 )
-from tests.helper_scripts.common_test_data import get_sample_agency_post_parameters
+from tests.helper_scripts.common_test_data import get_sample_agency_post_parameters, TestDataCreatorFlask
 from tests.helper_scripts.constants import AGENCIES_BASE_ENDPOINT
 from tests.helper_scripts.helper_functions import (
     create_test_user_setup_db_client,
@@ -36,6 +36,7 @@ from tests.helper_scripts.run_and_validate_request import run_and_validate_reque
 from tests.helper_scripts.helper_classes.IntegrationTestSetup import (
     IntegrationTestSetup,
 )
+from conftest import test_data_creator_flask, monkeysession
 
 
 @dataclass
@@ -53,14 +54,15 @@ def ts(integration_test_admin_setup: IntegrationTestSetup):
     )
 
 
-def test_agencies_get(flask_client_with_db, dev_db_client: DatabaseClient):
+def test_agencies_get(test_data_creator_flask: TestDataCreatorFlask):
     """
     Test that GET call to /agencies endpoint properly retrieves a nonzero amount of data
     """
-    tus = create_test_user_setup_db_client(dev_db_client)
+    tdc = test_data_creator_flask
+    tus = tdc.standard_user()
 
     response_json = run_and_validate_request(
-        flask_client=flask_client_with_db,
+        flask_client=tdc.flask_client,
         http_method="get",
         endpoint=AGENCIES_BASE_ENDPOINT + "?page=2",
         headers=tus.api_authorization_header,

--- a/tests/integration/test_api_key.py
+++ b/tests/integration/test_api_key.py
@@ -1,6 +1,6 @@
 """Integration tests for /api_key endpoint"""
-
-from resources.ApiKey import API_KEY_ROUTE
+from middleware.api_key import ApiKey
+from resources.ApiKeyResource import API_KEY_ROUTE, ApiKeyResource
 from tests.conftest import dev_db_client, flask_client_with_db
 from tests.helper_scripts.helper_functions import (
     create_test_user_api,
@@ -24,8 +24,9 @@ def test_api_key_post(flask_client_with_db, dev_db_client):
 
     # Check that API key aligned with user
     new_user_info = dev_db_client.get_user_info(user_info.email)
-    assert new_user_info.api_key == response_json.get(
-        "api_key"
-    ), "API key returned not aligned with user API key in database"
+    api_key_raw = response_json.get("api_key")
+    api_key = ApiKey(raw_key=api_key_raw)
+
+    assert new_user_info.api_key == api_key.key_hash, "API key returned not aligned with user API key in database"
 
 

--- a/tests/integration/test_api_key.py
+++ b/tests/integration/test_api_key.py
@@ -1,15 +1,11 @@
 """Integration tests for /api_key endpoint"""
 
-from http import HTTPStatus
-
-from database_client.database_client import DatabaseClient
 from resources.ApiKey import API_KEY_ROUTE
 from tests.conftest import dev_db_client, flask_client_with_db
 from tests.helper_scripts.helper_functions import (
     create_test_user_api,
 )
 from tests.helper_scripts.run_and_validate_request import run_and_validate_request
-from tests.helper_scripts.simple_result_validators import check_response_status
 
 
 def test_api_key_post(flask_client_with_db, dev_db_client):
@@ -31,3 +27,5 @@ def test_api_key_post(flask_client_with_db, dev_db_client):
     assert new_user_info.api_key == response_json.get(
         "api_key"
     ), "API key returned not aligned with user API key in database"
+
+

--- a/tests/integration/test_archives.py
+++ b/tests/integration/test_archives.py
@@ -24,15 +24,14 @@ from conftest import test_data_creator_flask, monkeysession
 ENDPOINT = "/api/archives"
 
 
-def test_archives_get(flask_client_with_db, dev_db_client: DatabaseClient):
+def test_archives_get(test_data_creator_flask: TestDataCreatorFlask):
     """
     Test that GET call to /archives endpoint successfully retrieves a non-zero amount of data
     """
-    tus = create_test_user_setup_db_client(
-        dev_db_client,
-    )
+    tdc = test_data_creator_flask
+    tus = tdc.standard_user()
     response_json = run_and_validate_request(
-        flask_client=flask_client_with_db,
+        flask_client=tdc.flask_client,
         http_method="get",
         endpoint=ENDPOINT,
         headers=tus.api_authorization_header,

--- a/tests/middleware/test_login_queries.py
+++ b/tests/middleware/test_login_queries.py
@@ -8,7 +8,7 @@ from database_client.database_client import DatabaseClient
 from database_client.enums import ExternalAccountTypeEnum
 from middleware.primary_resource_logic.login_queries import (
     generate_api_key,
-    get_api_key_for_user,
+    create_api_key_for_user,
     refresh_session,
 )
 from middleware.primary_resource_logic.callback_primary_logic import try_logging_in_with_github_id
@@ -51,7 +51,7 @@ def test_get_api_key_for_user_success(monkeypatch):
     mock.generate_api_key.return_value = mock.api_key
 
     # Call function
-    get_api_key_for_user(mock.db_client, mock.dto)
+    create_api_key_for_user(mock.db_client, mock.dto)
 
     assert_get_api_key_for_user_precondition_calls(mock)
 
@@ -67,7 +67,7 @@ def test_get_api_key_for_user_failure():
 
     mock.check_password_hash.return_value = False
 
-    get_api_key_for_user(mock.db_client, mock.dto)
+    create_api_key_for_user(mock.db_client, mock.dto)
 
     assert_get_api_key_for_user_precondition_calls(mock)
 

--- a/tests/middleware/test_security.py
+++ b/tests/middleware/test_security.py
@@ -1,25 +1,17 @@
-import datetime
-import uuid
 from http import HTTPStatus
-from typing import Callable
 
-import flask
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
-from flask import Flask
-
-from middleware import security
 from middleware.exceptions import (
     InvalidAPIKeyException,
     InvalidAuthorizationHeaderException,
 )
 from middleware.security import (
-    check_api_key_associated_with_user,
-    check_api_key,
     check_permissions,
-    INVALID_API_KEY_MESSAGE,
 )
+from middleware.primary_resource_logic.api_key_logic import INVALID_API_KEY_MESSAGE, \
+    check_api_key
 from middleware.decorators import api_key_required
 from tests.helper_scripts.DynamicMagicMock import DynamicMagicMock
 from tests.helper_scripts.common_mocks_and_patches import patch_abort
@@ -96,63 +88,3 @@ def test_check_permissions_user_does_not_have_permission(check_permissions_mocks
         message="You do not have permission to access this endpoint",
     )
 
-
-def test_check_api_key_associated_with_user_happy_path(mock_abort):
-    mock = MagicMock()
-    mock.db_client.get_user_by_api_key.return_value = mock.user_id
-    check_api_key_associated_with_user(mock.db_client, mock.api_key)
-    mock.db_client.get_user_by_api_key.assert_called_once_with(mock.api_key)
-    mock_abort.assert_not_called()
-
-
-def test_check_api_key_associated_with_user_invalid_api_key(mock_abort):
-    mock = MagicMock()
-    mock.db_client.get_user_by_api_key.return_value = None
-    check_api_key_associated_with_user(mock.db_client, mock.api_key)
-    mock.db_client.get_user_by_api_key.assert_called_once_with(mock.api_key)
-    mock_abort.assert_called_once_with(HTTPStatus.UNAUTHORIZED, "Invalid API Key")
-
-
-class CheckApiKeyMocks(DynamicMagicMock):
-    get_db_client: MagicMock
-    get_api_key_from_request_header: MagicMock
-    check_api_key_associated_with_user: MagicMock
-
-
-def test_check_api_key_happy_path():
-    mock = CheckApiKeyMocks(
-        patch_root=PATCH_ROOT,
-    )
-    mock.get_api_key_from_request_header.return_value = mock.api_key
-    mock.get_db_client.return_value = mock.db_client
-
-    check_api_key()
-
-    mock.get_api_key_from_request_header.assert_called_once()
-    mock.get_db_client.assert_called_once()
-    mock.check_api_key_associated_with_user.assert_called_once_with(
-        mock.db_client, mock.api_key
-    )
-
-
-@pytest.mark.parametrize(
-    "exception",
-    [
-        InvalidAuthorizationHeaderException,
-        InvalidAPIKeyException,
-    ],
-)
-def test_check_api_key_invalid_api_key(exception, mock_abort):
-    mock = CheckApiKeyMocks(
-        patch_root=PATCH_ROOT,
-    )
-    mock.get_api_key_from_request_header.side_effect = exception
-
-    check_api_key()
-
-    mock.get_api_key_from_request_header.assert_called_once()
-    mock.get_db_client.assert_not_called()
-    mock.check_api_key_associated_with_user.assert_not_called()
-    mock_abort.assert_called_once_with(
-        code=HTTPStatus.UNAUTHORIZED, message=INVALID_API_KEY_MESSAGE
-    )

--- a/tests/test_database_client.py
+++ b/tests/test_database_client.py
@@ -75,7 +75,6 @@ def test_add_new_user(live_database_client: DatabaseClient):
     password_digest = result.password_digest
     api_key = result.api_key
 
-    assert api_key is not None
     assert password_digest == "test_password"
 
     # Adding same user should produce a DuplicateUserError

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -13,7 +13,7 @@ from flask.testing import FlaskClient
 from flask_restful import Resource
 
 from resources.Agencies import AgenciesByPage, AgenciesById
-from resources.ApiKey import ApiKey, API_KEY_ROUTE
+from resources.ApiKeyResource import ApiKeyResource, API_KEY_ROUTE
 from resources.Archives import Archives
 from resources.Callback import Callback
 from resources.DataRequests import (
@@ -87,7 +87,7 @@ test_parameters = [
     TestParameters(User, "/user", [POST, PUT]),
     TestParameters(Login, "/login", [POST]),
     TestParameters(RefreshSession, "/refresh-session", [POST]),
-    TestParameters(ApiKey, f"/auth{API_KEY_ROUTE}", [POST]),
+    TestParameters(ApiKeyResource, f"/auth{API_KEY_ROUTE}", [POST]),
     TestParameters(RequestResetPassword, "/request-reset-password", [POST]),
     TestParameters(ResetPassword, "/reset-password", [POST]),
     TestParameters(ResetTokenValidation, "/reset-token-validation", [POST]),


### PR DESCRIPTION
### Fixes

* https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/388

### Description

* Reorganize API key logic; remove redundant tests.
* Add API logic to encrypt API keys with SHA256 hash

### Testing

* Run tests in `tests` directory to confirm expected functionality

### Performance

* Performance impact marginal. 

### Docs

* API Documentation unaffected

### Breaking Changes

* No breaking changes should occur -- API keys already existing in database were updated with the same hash encryption, and should still function.