### PR TITLE
Standardize `/refresh-session` response to align with `/login`. Update test and internal logic accordingly.

### DIFF
--- a/middleware/primary_resource_logic/login_queries.py
+++ b/middleware/primary_resource_logic/login_queries.py
@@ -4,12 +4,15 @@ from flask import Response, make_response, jsonify
 from flask_jwt_extended import (
     create_access_token,
     get_jwt_identity,
-    create_refresh_token,
+    create_refresh_token, decode_token,
 )
+from sqlalchemy.orm.loading import get_from_identity
 from werkzeug.security import check_password_hash
 
 from database_client.database_client import DatabaseClient
+from middleware.access_logic import AccessInfo
 from middleware.primary_resource_logic.user_queries import UserRequestDTO
+from middleware.schema_and_dto_logic.primary_resource_schemas.refresh_session_schemas import RefreshSessionRequestDTO
 
 
 def try_logging_in(db_client: DatabaseClient, dto: UserRequestDTO) -> Response:
@@ -57,15 +60,37 @@ def login_response(
         HTTPStatus.OK,
     )
 
+def access_and_refresh_token_response(
+    email: str,
+    message: str,
+) -> Response:
+    access_token = create_access_token(identity=email)
+    refresh_token = create_refresh_token(identity=email)
+    return make_response(
+        jsonify(
+            message=message,
+            access_token=access_token,
+            refresh_token=refresh_token,
+        ),
+        HTTPStatus.OK,
+    )
 
-def refresh_session() -> Response:
+def refresh_session(
+        db_client: DatabaseClient,
+        access_info: AccessInfo,
+        dto: RefreshSessionRequestDTO
+) -> Response:
     """
     Requires an active flask context and a valid JWT passed in the Authorization header
     :return:
     """
-    identity = get_jwt_identity()
-    access_token = create_access_token(identity=identity)
-    return make_response(
-        {"message": "Successfully refreshed session token", "data": access_token},
-        HTTPStatus.OK,
+    decoded_refresh_token = decode_token(dto.refresh_token)
+    decoded_email = decoded_refresh_token["sub"]
+    if access_info.user_email != decoded_email:
+        return make_response(
+            {"message": "Invalid refresh token"}, HTTPStatus.UNAUTHORIZED
+        )
+    return access_and_refresh_token_response(
+        email=decoded_email,
+        message="Successfully refreshed session token.",
     )

--- a/middleware/schema_and_dto_logic/primary_resource_schemas/refresh_session_schemas.py
+++ b/middleware/schema_and_dto_logic/primary_resource_schemas/refresh_session_schemas.py
@@ -1,0 +1,18 @@
+from dataclasses import dataclass
+
+from marshmallow import fields, Schema
+
+from middleware.schema_and_dto_logic.util import get_json_metadata
+
+
+class RefreshSessionRequestSchema(Schema):
+    refresh_token = fields.String(
+        required=True,
+        metadata=get_json_metadata(
+            "The refresh token for the user's PDAP account"
+        )
+    )
+
+@dataclass
+class RefreshSessionRequestDTO:
+    refresh_token: str

--- a/resources/RefreshSession.py
+++ b/resources/RefreshSession.py
@@ -1,11 +1,16 @@
+from http import HTTPStatus
+
 from flask import Response
 from flask_jwt_extended import jwt_required
 from flask_restx import fields
 
+from middleware.access_logic import WRITE_ONLY_AUTH_INFO, STANDARD_JWT_AUTH_INFO, AccessInfo
+from middleware.decorators import endpoint_info_2
 from middleware.primary_resource_logic.login_queries import (
     refresh_session,
 )
-from resources.resource_helpers import add_jwt_header_arg
+from resources.endpoint_schema_config import SchemaConfigs
+from resources.resource_helpers import add_jwt_header_arg, ResponseInfo
 
 from utilities.namespace import create_namespace
 from resources.PsycopgResource import PsycopgResource, handle_exceptions
@@ -35,18 +40,19 @@ class RefreshSession(PsycopgResource):
     If the provided session token is valid and not expired, it is replaced with a new one.
     """
 
-    @handle_exceptions
-    @namespace_refresh_session.expect(parser)
-    @namespace_refresh_session.response(
-        200, "OK; Successful session refresh", session_token_model
+    @endpoint_info_2(
+        namespace=namespace_refresh_session,
+        auth_info=STANDARD_JWT_AUTH_INFO,
+        description="Allows a user to refresh their session token.",
+        response_info=ResponseInfo(
+            response_dictionary={
+                HTTPStatus.OK: "OK; Successful session refresh.",
+                HTTPStatus.FORBIDDEN: "Forbidden invalid old session token",
+            }
+        ),
+        schema_config=SchemaConfigs.REFRESH_SESSION,
     )
-    @namespace_refresh_session.response(500, "Internal server error")
-    @namespace_refresh_session.response(403, "Forbidden invalid old session token")
-    @namespace_refresh_session.doc(
-        description="Allows a user to refresh their session token."
-    )
-    @jwt_required(refresh=True)
-    def post(self) -> Response:
+    def post(self, access_info: AccessInfo) -> Response:
         """
         Processes the session token refresh request. If the provided session token is valid,
         it generates a new session token, invalidates the old one, and returns the new token.
@@ -54,4 +60,9 @@ class RefreshSession(PsycopgResource):
         Returns:
         - A dictionary containing a message of success or failure, and the new session token if successful.
         """
-        return refresh_session()
+
+        return self.run_endpoint(
+            wrapper_function=refresh_session,
+            schema_populate_parameters=SchemaConfigs.REFRESH_SESSION.value.get_schema_populate_parameters(),
+            access_info=access_info
+        )

--- a/resources/endpoint_schema_config.py
+++ b/resources/endpoint_schema_config.py
@@ -9,6 +9,8 @@ from middleware.primary_resource_logic.data_requests import (
     RelatedSourceByIDSchema,
     RelatedSourceByIDDTO, DataRequestsPostDTO, RelatedLocationsByIDDTO,
 )
+from middleware.schema_and_dto_logic.primary_resource_schemas.refresh_session_schemas import \
+    RefreshSessionRequestSchema, RefreshSessionRequestDTO
 from middleware.schema_and_dto_logic.primary_resource_schemas.typeahead_suggestion_schemas import \
     TypeaheadAgenciesOuterResponseSchema, TypeaheadLocationsOuterResponseSchema, TypeaheadLocationsResponseSchema
 from middleware.primary_resource_logic.unique_url_checker import UniqueURLCheckerRequestSchema, \
@@ -277,7 +279,9 @@ class SchemaConfigs(Enum):
     #endregion
     #region Auth
     LOGIN_POST = EndpointSchemaConfig(
-        input_schema=UserRequestSchema(), primary_output_schema=LoginResponseSchema(), input_dto_class=UserRequestDTO
+        input_schema=UserRequestSchema(),
+        primary_output_schema=LoginResponseSchema(),
+        input_dto_class=UserRequestDTO
     )
     AUTH_GITHUB_LOGIN = EndpointSchemaConfig(
         primary_output_schema=LoginResponseSchema()
@@ -288,3 +292,8 @@ class SchemaConfigs(Enum):
         primary_output_schema=MessageSchema()
     )
     #endregion
+    REFRESH_SESSION = EndpointSchemaConfig(
+        input_schema=RefreshSessionRequestSchema(),
+        primary_output_schema=LoginResponseSchema(),
+        input_dto_class=RefreshSessionRequestDTO
+    )

--- a/tests/integration/test_refresh_session.py
+++ b/tests/integration/test_refresh_session.py
@@ -1,51 +1,81 @@
 """Integration tests for /refresh-session endpoint."""
-
-import urllib.parse
 from http import HTTPStatus
 
-from middleware.enums import PermissionsEnum
 from tests.conftest import flask_client_with_db, test_user_admin
+from tests.helper_scripts.common_test_data import TestDataCreatorFlask
 from tests.helper_scripts.helper_functions import (
     login_and_return_jwt_tokens,
-    create_test_user_setup_db_client,
 )
 from tests.helper_scripts.run_and_validate_request import run_and_validate_request
+from conftest import monkeysession, test_data_creator_flask
 
-
-def test_refresh_session_post(test_user_admin, flask_client_with_db):
+def test_refresh_session_post(test_data_creator_flask: TestDataCreatorFlask):
     """
     Test that POST call to /refresh-session endpoint successfully generates a new session token, ensures the new token is different from the old one, and verifies the old token is removed while the new token exists in the session tokens table
     """
+    tdc = test_data_creator_flask
+    admin_tus = tdc.get_admin_tus()
 
     jwt_tokens = login_and_return_jwt_tokens(
-        flask_client_with_db, test_user_admin.user_info
+        tdc.flask_client, admin_tus.user_info
     )
 
     # Test that the access token works properly for a secure endpoint
     run_and_validate_request(
-        flask_client=flask_client_with_db,
+        flask_client=tdc.flask_client,
         http_method="get",
-        endpoint="/auth/permissions?user_email=" + test_user_admin.user_info.email,
+        endpoint="/auth/permissions?user_email=" + admin_tus.user_info.email,
         headers={"Authorization": f"Bearer {jwt_tokens.access_token}"},
     )
 
+    # Test that the refresh token works properly
     response_json = run_and_validate_request(
-        flask_client=flask_client_with_db,
+        flask_client=tdc.flask_client,
         http_method="post",
         endpoint="/api/refresh-session",
-        headers={"Authorization": f"Bearer {jwt_tokens.refresh_token}"},
+        headers=admin_tus.jwt_authorization_header,
+        json={
+            "refresh_token": jwt_tokens.refresh_token
+        }
     )
 
-    new_session_token = response_json.get("data")
+    new_access_token = response_json.get("access_token")
+    new_refresh_token = response_json.get("refresh_token")
 
     assert (
-        jwt_tokens.access_token != new_session_token
-    ), "New and old tokens should be different"
+        jwt_tokens.access_token != new_access_token
+    ), "New and old access tokens should be different"
 
-    # Test that the old session tokens work on a secure endpoint, but not the new one
+    assert (
+        jwt_tokens.refresh_token != new_refresh_token
+    ), "New and old refresh tokens should be different"
+
+    # Test that the new session tokens work on a secure endpoint
     run_and_validate_request(
-        flask_client=flask_client_with_db,
+        flask_client=tdc.flask_client,
         http_method="get",
-        endpoint="/auth/permissions?user_email=" + test_user_admin.user_info.email,
-        headers={"Authorization": f"Bearer {new_session_token}"},
+        endpoint="/auth/permissions?user_email=" + admin_tus.user_info.email,
+        headers={"Authorization": f"Bearer {new_access_token}"},
+    )
+
+def test_refresh_session_post_invalid_refresh_token(test_data_creator_flask: TestDataCreatorFlask):
+    tdc = test_data_creator_flask
+    admin_tus = tdc.get_admin_tus()
+
+    standard_tus = tdc.standard_user()
+
+    jwt_tokens = login_and_return_jwt_tokens(
+        tdc.flask_client, standard_tus.user_info
+    )
+
+    # Test that refresh session fails when the refresh token is invalid
+    response_json = run_and_validate_request(
+        flask_client=tdc.flask_client,
+        http_method="post",
+        endpoint="/api/refresh-session",
+        headers=admin_tus.jwt_authorization_header,
+        json={
+            "refresh_token": f"{jwt_tokens.refresh_token}"
+        },
+        expected_response_status=HTTPStatus.UNAUTHORIZED
     )

--- a/tests/middleware/test_login_queries.py
+++ b/tests/middleware/test_login_queries.py
@@ -21,23 +21,6 @@ def test_generate_api_key():
     assert all(c in "0123456789abcdef" for c in api_key)
 
 
-class RefreshSessionMocks(DynamicMagicMock):
-    make_response: MagicMock
-    create_session_token: MagicMock
-
-
-@pytest.fixture
-def setup_refresh_session_mocks():
-    mock = RefreshSessionMocks(
-        patch_root=PATCH_ROOT,
-    )
-    mock.db_client.get_session_token_info.return_value = mock.session_token_info
-    mock.create_session_token.return_value = mock.new_token
-    mock.session_token_info.resource_id = mock.mock_user_id
-    mock.session_token_info.email = mock.mock_email
-
-    return mock
-
 
 class TryLoggingInWithGithubIdMocks(DynamicMagicMock):
     unauthorized_response: MagicMock
@@ -65,25 +48,3 @@ def setup_try_logging_in_with_github_id_mocks():
 
     mock.github_user_info.user_id = mock.github_user_id
     return mock
-
-class RefreshSessionMocks(DynamicMagicMock):
-    get_jwt_identity: MagicMock
-    create_access_token: MagicMock
-    make_response: MagicMock
-
-
-def test_refresh_session():
-    mock = RefreshSessionMocks(
-        patch_root=PATCH_ROOT,
-    )
-    mock.get_jwt_identity.return_value = mock.identity
-    mock.create_access_token.return_value = mock.access_token
-
-    refresh_session()
-
-    mock.get_jwt_identity.assert_called_once()
-    mock.create_access_token.assert_called_once_with(identity=mock.identity)
-    mock.make_response.assert_called_once_with(
-        {"message": "Successfully refreshed session token", "data": mock.access_token},
-        HTTPStatus.OK,
-    )


### PR DESCRIPTION
### Fixes

* https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/491

### Description

* Standardizes `/refresh-session` response to align with `/login` response, returning both access token and refresh token
* Updates backend logic accordingly
* Updates tests accordingly

### Testing

* Run tests in `tests` directory
* Inspect API documentation to confirm proper functionality

### Performance

* Adds extra backend logic to `/refresh-session` to bring in line with `/login` response, but performance impact marginal
* Increase in test overhead due to addition of new integration test

### Docs

* API documentation updated

### Breaking Changes

* `/refresh-session` endpoint now no longer returns access token via `data` key-value pair, but via `access-token` key-value pair.
* An additional key-value pair for `refresh-token` now exists in this response.