### PR TITLE
Add user id to jwt

### DIFF
--- a/middleware/access_logic.py
+++ b/middleware/access_logic.py
@@ -62,10 +62,10 @@ def get_access_info_from_jwt() -> Optional[AccessInfo]:
     jwt_in_request = verify_jwt_in_request()
     if jwt_in_request is None:
         return None
-    user_email = get_jwt_identity()
-    if user_email is None:
+    identity = get_jwt_identity()
+    if identity is None:
         return None
-    return get_jwt_access_info_with_permissions(user_email)
+    return get_jwt_access_info_with_permissions(identity["user_email"])
 
 
 def get_jwt_access_info_with_permissions(user_email):

--- a/middleware/security.py
+++ b/middleware/security.py
@@ -16,9 +16,10 @@ def check_permissions(permission: PermissionsEnum) -> None:
     :return: True if the user has the permission, False otherwise.
     """
     verify_jwt_in_request()
-    user_email = get_jwt_identity()
+    identity = get_jwt_identity()
+    email = identity["user_email"]
     db_client = get_db_client()
-    pm = PermissionsManager(db_client=db_client, user_email=user_email)
+    pm = PermissionsManager(db_client=db_client, user_email=email)
     if not pm.has_permission(permission):
         abort(
             code=HTTPStatus.FORBIDDEN,

--- a/resources/RefreshSession.py
+++ b/resources/RefreshSession.py
@@ -21,22 +21,6 @@ from resources.PsycopgResource import PsycopgResource, handle_exceptions
 
 namespace_refresh_session = create_namespace()
 
-parser = namespace_refresh_session.parser()
-
-add_jwt_header_arg(parser)
-
-session_token_model = namespace_refresh_session.model(
-    "SessionToken",
-    {
-        "data": fields.String(
-            required=True,
-            description="The session token",
-            example="2bd77a1d7ef24a1dad3365b8a5c6994e",
-        ),
-    },
-)
-
-
 @namespace_refresh_session.route("/refresh-session")
 class RefreshSession(PsycopgResource):
     """

--- a/tests/helper_scripts/common_test_functions.py
+++ b/tests/helper_scripts/common_test_functions.py
@@ -35,7 +35,7 @@ def assert_api_key_exists_for_email(db_client: DatabaseClient, email: str, api_k
 
 def assert_jwt_token_matches_user_email(email: str, jwt_token: str):
     decoded_token = decode_token(jwt_token)
-    assert email == decoded_token["sub"]
+    assert email == decoded_token["sub"]["user_email"]
 
 
 def assert_expected_get_many_result(

--- a/tests/middleware/test_access_logic.py
+++ b/tests/middleware/test_access_logic.py
@@ -413,57 +413,6 @@ def test_get_user_email_from_api_key(
     else:
         assert result == expected_result.email
 
-
-@pytest.mark.parametrize(
-    "verify_jwt_in_request_result, "
-    "get_jwt_identity_result, "
-    "get_jwt_access_info_with_permissions_called",
-    (
-        # Happy path
-        (MagicMock(), None, False),
-        (None, MagicMock(), False),
-        (MagicMock(), MagicMock(), True),
-    ),
-)
-def test_get_access_info_from_jwt(
-    verify_jwt_in_request_result,
-    get_jwt_identity_result,
-    get_jwt_access_info_with_permissions_called,
-    monkeypatch,
-):
-
-    mock_verify_jwt_in_request = MagicMock(return_value=verify_jwt_in_request_result)
-    mock_get_jwt_identity = MagicMock(return_value=get_jwt_identity_result)
-    mock_get_jwt_access_info_with_permissions = MagicMock()
-    monkeypatch.setattr(
-        "middleware.access_logic.verify_jwt_in_request", mock_verify_jwt_in_request
-    )
-    monkeypatch.setattr(
-        "middleware.access_logic.get_jwt_identity", mock_get_jwt_identity
-    )
-    monkeypatch.setattr(
-        "middleware.access_logic.get_jwt_access_info_with_permissions",
-        mock_get_jwt_access_info_with_permissions,
-    )
-
-    mock = MagicMock()
-
-    monkeypatch.setattr(
-        "middleware.access_logic.get_db_client", MagicMock(return_value=mock.db_client)
-    )
-
-    result = get_access_info_from_jwt()
-
-    if get_jwt_access_info_with_permissions_called:
-        assert result == mock_get_jwt_access_info_with_permissions.return_value
-        mock_get_jwt_access_info_with_permissions.assert_called_once_with(
-            mock_get_jwt_identity.return_value
-        )
-    else:
-        assert result is None
-        mock_get_jwt_access_info_with_permissions.assert_not_called()
-
-
 def test_get_jwt_access_info_with_permissions(monkeypatch):
 
     mock = MagicMock()

--- a/tests/middleware/test_security.py
+++ b/tests/middleware/test_security.py
@@ -51,7 +51,7 @@ def check_permissions_mocks():
     mock = CheckPermissionsMocks(
         patch_root=PATCH_ROOT,
     )
-    mock.get_jwt_identity.return_value = mock.user_email
+    mock.get_jwt_identity.return_value = {"user_email": mock.user_email, "id": mock.id}
     mock.get_db_client.return_value = mock.db_client
     mock.PermissionsManager.return_value = mock.permissions_manager_instance
     return mock


### PR DESCRIPTION
### Fixes

* https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/507

### Description

* Updates JWT identity to include user id as well as email

### Testing

* Run tests in `tests` directory to confirm functionality

### Performance

* Performance impact marginal

### Docs

* No changes to documentation. 

### Breaking Changes

* The structure of the JWT `sub` key-value pair has changed. Whereas previously it was a string, it is now a dictionary with the structure:
```
{
  "id": int,
  "user_email": str
}
```
