### PR TITLE
Change Github Access Token to JWT with Expiry of 5 minutes.

### DIFF
--- a/middleware/SimpleJWT.py
+++ b/middleware/SimpleJWT.py
@@ -1,0 +1,46 @@
+import datetime
+
+import jwt
+
+from middleware.util import get_env_variable
+
+SECRET_KEY = get_env_variable("JWT_SECRET_KEY")
+ALGORITHM = "HS256"
+
+class SimpleJWT:
+
+    def __init__(
+        self,
+        sub: str,
+        exp: float
+    ):
+        self.sub = sub
+        self.exp = exp
+
+
+    def encode(self):
+        payload = {
+            "sub": self.sub,
+            "exp": self.exp
+        }
+        return jwt.encode(
+            payload=payload,
+            key=SECRET_KEY,
+            algorithm=ALGORITHM
+        )
+
+    @staticmethod
+    def decode(token):
+        payload = jwt.decode(
+            jwt=token,
+            key=SECRET_KEY,
+            algorithms=[ALGORITHM]
+        )
+        return SimpleJWT(
+            sub=payload["sub"],
+            exp=payload["exp"],
+        )
+
+    def is_expired(self):
+        return self.exp < datetime.datetime.now(tz=datetime.timezone.utc).timestamp()
+

--- a/middleware/third_party_interaction_logic/callback_oauth_logic.py
+++ b/middleware/third_party_interaction_logic/callback_oauth_logic.py
@@ -55,7 +55,7 @@ def get_github_user_id(token: str) -> int:
 
 
 
-def get_github_oauth_access_token() -> str:
+def get_github_oauth_access_token() -> dict:
     """
     Gets the access token from the Github API via OAuth2
     :return: The access token

--- a/resources/LinkToGithub.py
+++ b/resources/LinkToGithub.py
@@ -36,10 +36,10 @@ class LinkToGithub(PsycopgResource):
         schema_config=SchemaConfigs.AUTH_GITHUB_LINK,
         response_info=ResponseInfo(
             response_dictionary={
-                HTTPStatus.OK: "Callback response. Accounts linked.",
-                HTTPStatus.BAD_REQUEST: "Bad request. Provided email doesn't have associated PDAP account or GitHub acccount doesn't match associated PDAP account.",
-                HTTPStatus.FOUND: "Returns redirect link to OAuth.",
-                HTTPStatus.INTERNAL_SERVER_ERROR: "Internal Server Error.",
+                HTTPStatus.OK.value: "Accounts linked.",
+                HTTPStatus.BAD_REQUEST.value: "Bad request. Provided email doesn't have associated PDAP account or GitHub acccount doesn't match associated PDAP account.",
+                HTTPStatus.UNAUTHORIZED.value: "Unauthorized. Forbidden or invalid authentication.",
+                HTTPStatus.INTERNAL_SERVER_ERROR.value: "Internal Server Error.",
             },
         ),
         description="""

--- a/resources/LoginWithGithub.py
+++ b/resources/LoginWithGithub.py
@@ -22,8 +22,9 @@ class LoginWithGithub(PsycopgResource):
         schema_config=SchemaConfigs.AUTH_GITHUB_LOGIN,
         response_info=ResponseInfo(
             response_dictionary={
-                HTTPStatus.OK: "Callback response. User logged in.",
-                HTTPStatus.FOUND: "Returns redirect link to OAuth.",
+                HTTPStatus.OK.value: "User logged in.",
+                HTTPStatus.BAD_REQUEST.value: "Bad request.",
+                HTTPStatus.UNAUTHORIZED.value: "Unauthorized. Forbidden or invalid authentication.",
                 HTTPStatus.INTERNAL_SERVER_ERROR: "Internal Server Error.",
             },
         ),

--- a/tests/middleware/test_callback_primary_logic.py
+++ b/tests/middleware/test_callback_primary_logic.py
@@ -134,28 +134,3 @@ def test_link_github_account():
         external_account_type=ExternalAccountTypeEnum.GITHUB,
     )
 
-
-class GetGithubUserInfoMocks(DynamicMagicMock):
-    get_github_user_id: MagicMock
-    get_github_user_email: MagicMock
-
-
-def test_get_github_user_info():
-
-    mock = GetGithubUserInfoMocks(
-        patch_root=GITHUB_OAUTH_PREFIX,
-        return_values={
-            "get_github_user_id": MagicMock(),
-            "get_github_user_email": MagicMock(),
-        },
-    )
-
-    result = get_github_user_info(access_token=mock.access_token)
-
-    assert isinstance(result, GithubUserInfo)
-
-    mock.get_github_user_id.assert_called_once_with(mock.access_token)
-    mock.get_github_user_email.assert_called_once_with(mock.access_token)
-
-    assert result.user_email == mock.get_github_user_email.return_value
-    assert result.user_id == mock.get_github_user_id.return_value


### PR DESCRIPTION
### Fixes

* https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/515

### Description

* Update Github Access Token returned by `/callback` to instead be a JWT, valid only for the app, and with an expiration time of 5 minutes.

### Testing

* Run tests in `tests` to confirm functionality
* Additionally, can test by running the OAuth lifecycle, retrieving the access token, and running it initially to confirm it still functions properly, then running it again after 5 minutes to confirm it properly expires.

### Performance

* Impact marginal.

### Docs

* Some minor tweaks to documentation

### Breaking Changes

* Logic of GitHub Access Token remains the same
* The token remains a string, but is longer and is in the typical JWT format.