### PR TITLE
* Adjust logic to account for removed data_sources.record_download_op…

### DIFF
--- a/database_client/models.py
+++ b/database_client/models.py
@@ -515,7 +515,6 @@ class DataSource(Base, CountMetadata, CountSubqueryMetadata):
     access_types = Column(
         ARRAY(pgEnum(*[e.value for e in AccessType], name="access_type"))
     )
-    record_download_option_provided: Mapped[Optional[bool]]
     data_portal_type: Mapped[Optional[str]]
     record_formats = Column(ARRAY(String))
     update_method: Mapped[Optional[UpdateMethodLiteral]]

--- a/middleware/schema_and_dto_logic/primary_resource_schemas/data_sources_schemas.py
+++ b/middleware/schema_and_dto_logic/primary_resource_schemas/data_sources_schemas.py
@@ -44,7 +44,6 @@ class DataSourceEntryDataPostDTO:
     coverage_end: Optional[date] = None
     detail_level: Optional[DetailLevel] = None
     access_types: Optional[List[AccessType]] = None
-    record_download_option_provided: Optional[bool] = None
     data_portal_type: Optional[str] = None
     record_formats: Optional[List[str]] = None
     update_method: Optional[str] = None
@@ -173,12 +172,6 @@ class DataSourceBaseSchema(Schema):
         allow_none=True,
         metadata=get_json_metadata(
             "The ways the data source can be accessed. Editable only by admins."
-        ),
-    )
-    record_download_option_provided = fields.Boolean(
-        allow_none=True,
-        metadata=get_json_metadata(
-            "Is there a way to download the data source's records?"
         ),
     )
     data_portal_type = fields.String(

--- a/tests/integration/test_archives.py
+++ b/tests/integration/test_archives.py
@@ -36,7 +36,6 @@ def test_archives_put(
     tdc = test_data_creator_flask
     data_source_id = tdc.data_source().id
     last_cached = datetime.datetime(year=2020, month=3, day=4)
-    broken_as_of = datetime.date(year=1993, month=11, day=13)
     test_user_admin = tdc.get_admin_tus()
     test_user_admin.jwt_authorization_header["Content-Type"] = "application/json"
     run_and_validate_request(
@@ -48,7 +47,6 @@ def test_archives_put(
             {
                 "id": data_source_id,
                 "last_cached": str(last_cached),
-                "broken_source_url_as_of": str(broken_as_of),
             }
         ),
     )
@@ -63,4 +61,4 @@ def test_archives_put(
         vars=(int(data_source_id),),
     )
     assert row[0]["last_cached"] == last_cached
-    assert row[0]["broken_source_url_as_of"] == broken_as_of
+    assert row[0]["broken_source_url_as_of"] is None

--- a/tests/integration/test_data_sources.py
+++ b/tests/integration/test_data_sources.py
@@ -168,7 +168,6 @@ def test_data_sources_by_id_put(test_data_creator_flask: TestDataCreatorFlask):
             AccessType.WEB_PAGE.value,
             AccessType.DOWNLOAD.value,
         ],
-        "record_download_option_provided": True,
         "data_portal_type": uuid.uuid4().hex,
         "record_formats": [uuid.uuid4().hex, uuid.uuid4().hex],
         "update_method": UpdateMethod.INSERT.value,


### PR DESCRIPTION
### Fixes

* https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/498
* https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/496

### Description

* Adjust logic to account for removed data_sources.record_download_option_provided column
* Add test for update_broken_source_url_as_of

### Testing

* Run tests in `tests` directory, confirm run without error

### Performance

* Impact marginal

### Docs

* Minor change to API schema documentation for `data_sources`: removal of `record_download_option_provided`

### Breaking Changes

* `record_download_option_provided` option for data sources removed.