### PR TITLE
Mc 470 refine rate limits

### DIFF
--- a/resources/Agencies.py
+++ b/resources/Agencies.py
@@ -93,7 +93,7 @@ class AgenciesById(PsycopgResource):
             column_permissions_str_table=agencies_column_permissions,
         ),
     )
-    @limiter.limit("50 per minute")
+    @limiter.limit("50/minute;250/hour")
     def get(self, resource_id: str, access_info: AccessInfo) -> Response:
         return self.run_endpoint(
             wrapper_function=get_agency_by_id,

--- a/resources/Agencies.py
+++ b/resources/Agencies.py
@@ -1,5 +1,6 @@
 from flask import Response
 
+from config import limiter
 from middleware.access_logic import AccessInfo, GET_AUTH_INFO, WRITE_ONLY_AUTH_INFO
 from middleware.column_permission_logic import create_column_permissions_string_table
 from middleware.decorators import (
@@ -92,6 +93,7 @@ class AgenciesById(PsycopgResource):
             column_permissions_str_table=agencies_column_permissions,
         ),
     )
+    @limiter.limit("50 per minute")
     def get(self, resource_id: str, access_info: AccessInfo) -> Response:
         return self.run_endpoint(
             wrapper_function=get_agency_by_id,

--- a/resources/DataRequests.py
+++ b/resources/DataRequests.py
@@ -1,5 +1,6 @@
 from flask import Response
 
+from config import limiter
 from middleware.access_logic import (
     AccessInfo,
     GET_AUTH_INFO,
@@ -55,6 +56,7 @@ class DataRequestsById(PsycopgResource):
         ),
         description="Get data request by id",
     )
+    @limiter.limit("50 per minute")
     def get(self, access_info: AccessInfo, resource_id: str) -> Response:
         """
         Get data request by id

--- a/resources/DataRequests.py
+++ b/resources/DataRequests.py
@@ -56,7 +56,7 @@ class DataRequestsById(PsycopgResource):
         ),
         description="Get data request by id",
     )
-    @limiter.limit("50 per minute")
+    @limiter.limit("50/minute;250/hour")
     def get(self, access_info: AccessInfo, resource_id: str) -> Response:
         """
         Get data request by id

--- a/resources/DataSources.py
+++ b/resources/DataSources.py
@@ -1,5 +1,6 @@
 from flask import Response
 
+from config import limiter
 from middleware.access_logic import (
     AccessInfo,
     WRITE_ONLY_AUTH_INFO,
@@ -59,6 +60,7 @@ class DataSourceById(PsycopgResource):
         ),
         description="Get details of a specific data source by its ID.",
     )
+    @limiter.limit("50 per minute")
     def get(self, access_info: AccessInfo, resource_id: str) -> Response:
         """
         Retrieves details of a specific data source by its ID.

--- a/resources/DataSources.py
+++ b/resources/DataSources.py
@@ -60,7 +60,7 @@ class DataSourceById(PsycopgResource):
         ),
         description="Get details of a specific data source by its ID.",
     )
-    @limiter.limit("50 per minute")
+    @limiter.limit("50/minute;250/hour")
     def get(self, access_info: AccessInfo, resource_id: str) -> Response:
         """
         Retrieves details of a specific data source by its ID.


### PR DESCRIPTION
### Fixes

* https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/470

### Description

* `GET-BY-ID` endpoints for `/agencies`, `/data-sources`, and `/data-requests` are now rate limited to 50 per minute, 250 per hour.

### Testing

* Run all tests in `/tests` directory and confirm functionality

### Performance

* Impact marginal

### Docs

* No changes to docs

### Breaking Changes

* No breaking changes.