### PR TITLE
* Update `/data-sources` `POST` to enable linking agency ids.

### DIFF
--- a/database_client/database_client.py
+++ b/database_client/database_client.py
@@ -303,7 +303,7 @@ class DatabaseClient:
                 DATA_SOURCES.NAME,
                 AGENCIES.ID AS AGENCY_ID,
                 AGENCIES.SUBMITTED_NAME AS AGENCY_NAME,
-                AGENCIES.STATE_ISO,
+                LE.STATE_ISO,
                 LE.LOCALITY_NAME AS MUNICIPALITY,
                 LE.COUNTY_NAME,
                 RT.NAME RECORD_TYPE,
@@ -722,10 +722,6 @@ class DatabaseClient:
             statement = statement.returning(column)
         result = self.session.execute(statement)
 
-        # query = DynamicQueryConstructor.create_insert_query(
-        #     table_name, column_value_mappings, column_to_return
-        # )
-        # self.cursor.execute(query)
         if column_to_return is not None:
             return result.fetchone()[0]
         return None

--- a/middleware/dynamic_request_logic/supporting_classes.py
+++ b/middleware/dynamic_request_logic/supporting_classes.py
@@ -93,4 +93,8 @@ class PutPostBase(ABC):
             self.check_can_edit_columns(relation_role)
         self.pre_database_client_method_logic()
         self.call_database_client_method()
+        self.post_database_client_method_logic()
         return self.make_response()
+
+    def post_database_client_method_logic(self):
+        return

--- a/middleware/schema_and_dto_logic/primary_resource_schemas/data_sources_schemas.py
+++ b/middleware/schema_and_dto_logic/primary_resource_schemas/data_sources_schemas.py
@@ -69,6 +69,7 @@ class DataSourceEntryDataPostDTO:
 @dataclass
 class DataSourcesPostDTO:
     entry_data: DataSourceEntryDataPostDTO
+    linked_agency_ids: Optional[List[int]] = None
 
 
 class DataSourceBaseSchema(Schema):
@@ -381,6 +382,15 @@ class DataSourcesPostSchema(Schema):
             description="The data source to be created",
             nested_dto_class=DataSourceEntryDataPostDTO,
         ),
+    )
+    linked_agency_ids = fields.List(
+        fields.Integer(
+            allow_none=True,
+            metadata=get_json_metadata(
+                "The agency ids associated with the data source."
+            ),
+        ),
+        metadata=get_json_metadata("The agency ids associated with the data source."),
     )
 
 

--- a/tests/integration/test_data_sources.py
+++ b/tests/integration/test_data_sources.py
@@ -1,5 +1,5 @@
 """Integration tests for /data-sources endpoint"""
-
+import copy
 import urllib.parse
 import uuid
 
@@ -119,6 +119,8 @@ def test_data_sources_post(
     """
     tdc = test_data_creator_flask
 
+    agency_id = tdc.agency().id
+
     entry_data = generate_test_data_from_schema(
         schema=DataSourceExpandedSchema(
             exclude=[
@@ -131,8 +133,8 @@ def test_data_sources_post(
                 "approval_status_updated_at",
             ],
         ),
-
     )
+
 
     response_json = run_and_validate_request(
         flask_client=tdc.flask_client,
@@ -141,6 +143,7 @@ def test_data_sources_post(
         headers=tdc.get_admin_tus().jwt_authorization_header,
         json={
             "entry_data": entry_data,
+            "linked_agency_ids": [agency_id],
         },
         expected_schema=SchemaConfigs.DATA_SOURCES_POST.value.primary_output_schema,
     )
@@ -157,6 +160,10 @@ def test_data_sources_post(
         dict_to_check=response_json["data"],
         key_value_pairs=entry_data,
     )
+
+    agencies = response_json["data"]["agencies"]
+    assert len(agencies) == 1
+    assert agencies[0]["id"] == int(agency_id)
 
 
 def test_data_sources_by_id_get(test_data_creator_flask: TestDataCreatorFlask):


### PR DESCRIPTION
### Fixes

* https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/526

### Description

* Update `/data-sources` `POST` to enable linking agency ids.
* Update corresponding tests
* LIBTYFI: Correct bug in `DatabaseClient.get_data_sources_for_map()`

### Testing

* Run tests in `tests` directory; confirm all function as expected
* Inspect API to confirm presence of `linked_agency_ids` key.

### Performance

* Additional network calls added to `/data-sources` `POST` logic: O(n) where n is number of agency ids included.

### Docs

* API documentation updated

### Breaking Changes

* No breaking changes.