### PR TITLE
Modify the format of the reset password link

### DIFF
--- a/middleware/webhook_logic.py
+++ b/middleware/webhook_logic.py
@@ -22,7 +22,7 @@ def post_to_webhook(msg: str):
 def send_password_reset_link(email, token):
     body = (
         f"To reset your password, click the following link: "
-        f"{get_env_variable('VITE_VUE_APP_BASE_URL')}/reset-password/{token}"
+        f"{get_env_variable('VITE_VUE_APP_BASE_URL')}/reset-password?token={token}"
     )
     send_via_mailgun(
         to_email=email,


### PR DESCRIPTION
### Fixes

* https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/524

### Description

* Modifies the format of the reset password link from `/reset-password/{JWT}` to `/reset-password?token={JWT}`.

### Testing

* Run tests in `tests` directory to confirm all continues to run as expected.

### Performance

* No performance impact

### Docs

* No documentation change.

### Breaking Changes

* Logic expecting reset password JWT in previous format will now break.