### PR TITLE
Add logic for automatically specifying last approval editor

### DIFF
--- a/database_client/database_client.py
+++ b/database_client/database_client.py
@@ -183,7 +183,7 @@ class DatabaseClient:
         )
         if len(results) == 0:
             return None
-        return results[0]["id"]
+        return int(results[0]["id"])
 
     def set_user_password_digest(self, email: str, password_digest: str):
         """

--- a/database_client/models.py
+++ b/database_client/models.py
@@ -542,6 +542,7 @@ class DataSource(Base, CountMetadata, CountSubqueryMetadata):
         ForeignKey("public.record_types.id")
     )
     approval_status_updated_at: Mapped[Optional[timestamp_tz]]
+    last_approval_editor_old: Mapped[Optional[str]]
 
     agencies: Mapped[list[AgencyExpanded]] = relationship(
         argument="AgencyExpanded",

--- a/database_client/models.py
+++ b/database_client/models.py
@@ -528,7 +528,7 @@ class DataSource(Base, CountMetadata, CountSubqueryMetadata):
     )
     submission_notes: Mapped[Optional[str]]
     rejection_note: Mapped[Optional[str]]
-    last_approval_editor: Mapped[Optional[str]]
+    last_approval_editor: Mapped[Optional[int]]
     submitter_contact_info: Mapped[Optional[str]]
     agency_described_submitted: Mapped[Optional[str]]
     agency_described_not_in_database: Mapped[Optional[str]]

--- a/middleware/primary_resource_logic/data_sources_logic.py
+++ b/middleware/primary_resource_logic/data_sources_logic.py
@@ -10,8 +10,6 @@ from database_client.subquery_logic import SubqueryParameters, SubqueryParameter
 from database_client.enums import ApprovalStatus
 from database_client.result_formatter import ResultFormatter
 from middleware.access_logic import AccessInfo
-from middleware.column_permission_logic import RelationRoleParameters
-from middleware.custom_dataclasses import DeferredFunction
 from middleware.dynamic_request_logic.delete_logic import delete_entry
 from middleware.dynamic_request_logic.get_by_id_logic import get_by_id
 from middleware.dynamic_request_logic.get_many_logic import get_many
@@ -134,6 +132,14 @@ def delete_data_source_wrapper(
     )
 
 
+def optionally_add_last_approval_editor(
+        entry_data: dict,
+        access_info: AccessInfo
+):
+    if "approval_status" in entry_data:
+        entry_data["last_approval_editor"] = access_info.get_user_id()
+
+
 def update_data_source_wrapper(
     db_client: DatabaseClient,
     dto: EntryCreateUpdateRequestDTO,
@@ -142,6 +148,7 @@ def update_data_source_wrapper(
 ) -> Response:
     entry_data = dto.entry_data
     optionally_swap_record_type_name_with_id(db_client, entry_data)
+    optionally_add_last_approval_editor(entry_data, access_info)
     return put_entry(
         middleware_parameters=MiddlewareParameters(
             db_client=db_client,

--- a/middleware/schema_and_dto_logic/primary_resource_schemas/data_sources_schemas.py
+++ b/middleware/schema_and_dto_logic/primary_resource_schemas/data_sources_schemas.py
@@ -310,6 +310,13 @@ class DataSourceBaseSchema(Schema):
             "The date and time the approval status was last updated"
         )
     )
+    last_approval_editor_old = fields.String(
+        allow_none=True,
+        metadata=get_json_metadata(
+            "Former identifier of who provided approval for the data source."
+        ),
+
+    )
 
 
 class DataSourceExpandedSchema(DataSourceBaseSchema):

--- a/middleware/schema_and_dto_logic/primary_resource_schemas/data_sources_schemas.py
+++ b/middleware/schema_and_dto_logic/primary_resource_schemas/data_sources_schemas.py
@@ -244,9 +244,9 @@ class DataSourceBaseSchema(Schema):
     rejection_note = fields.String(
         allow_none=True, metadata=get_json_metadata("Why the note was rejected.")
     )
-    last_approval_editor = fields.String(
+    last_approval_editor = fields.Integer(
         allow_none=True,
-        metadata=get_json_metadata("Who provided approval for the data source."),
+        metadata=get_json_metadata("User id of the user who provided approval for the data source."),
     )
     submitter_contact_info = fields.String(
         allow_none=True,
@@ -373,7 +373,8 @@ class DataSourcesPostSchema(Schema):
                 "created_at",
                 "record_type_id",
                 "approval_status_updated_at",
-                "broken_source_url_as_of"
+                "broken_source_url_as_of",
+                "last_approval_editor"
             ],
             partial=True,
         ),
@@ -406,7 +407,8 @@ class DataSourcesPutSchema(Schema):
                 "record_type_id",
                 "data_source_request",
                 "approval_status_updated_at",
-                "broken_source_url_as_of"
+                "broken_source_url_as_of",
+                "last_approval_editor"
             ]
         ),
         required=True,

--- a/tests/helper_scripts/helper_classes/TestDataCreatorDBClient.py
+++ b/tests/helper_scripts/helper_classes/TestDataCreatorDBClient.py
@@ -101,17 +101,19 @@ class TestDataCreatorDBClient:
             like_column_name="name",
         )
 
+        # Remove test data from data source
+        self.helper.delete_test_like(
+            table_name=Relations.DATA_SOURCES.value,
+            like_column_name="name",
+        )
+
+
         # Remove test data from user
         self.helper.delete_test_like(
             table_name=Relations.USERS.value,
             like_column_name="email",
         )
 
-        # Remove test data from data source
-        self.helper.delete_test_like(
-            table_name=Relations.DATA_SOURCES.value,
-            like_column_name="name",
-        )
 
 
 

--- a/tests/integration/test_data_sources.py
+++ b/tests/integration/test_data_sources.py
@@ -134,7 +134,8 @@ def test_data_sources_post(
                 "record_type_id",
                 "broken_source_url_as_of",
                 "approval_status_updated_at",
-                "last_approval_editor"
+                "last_approval_editor",
+                "last_approval_editor_old"
             ],
         ),
     )


### PR DESCRIPTION
### Fixes

* https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/499

### Description

* A brief description of what this does. Include screenshots, if anything should change visually.

### Testing

* Run tests in `tests` directory and confirm functionality
* Inspect API can confirm change to `last_approval_editor` definition in `/data-sources` `GET` as well as its absence in `/data-sources` `PUT`

### Performance

* Impact marginal

### Docs

* Accompanying docs PRs, if applicable

### Breaking Changes

* `last_approval_editor` can no longer be directly edited by the user. 
