### PR TITLE
Create endpoint for withdrawing data requests

### DIFF
--- a/resources/DataRequests.py
+++ b/resources/DataRequests.py
@@ -17,7 +17,7 @@ from middleware.primary_resource_logic.data_requests import (
     create_data_request_related_source,
     get_data_request_related_locations,
     create_data_request_related_location,
-    delete_data_request_related_location,
+    delete_data_request_related_location, withdraw_data_request_wrapper,
 )
 from middleware.schema_and_dto_logic.common_schemas_and_dtos import (
     EntryCreateUpdateRequestDTO,
@@ -29,7 +29,6 @@ from middleware.decorators import (
     endpoint_info_2,
 )
 from middleware.schema_and_dto_logic.non_dto_dataclasses import SchemaPopulateParameters
-from middleware.schema_and_dto_logic.primary_resource_schemas.data_requests_base_schema import DataRequestsSchema
 from resources.PsycopgResource import PsycopgResource
 from resources.resource_helpers import (
     create_response_dictionary,
@@ -213,6 +212,28 @@ class DataRequestsRelatedSourcesById(PsycopgResource):
             schema_populate_parameters=SchemaConfigs.DATA_REQUESTS_RELATED_SOURCES_POST.value.get_schema_populate_parameters(),
             access_info=access_info,
         )
+
+@namespace_data_requests.route("/<resource_id>/withdraw")
+class DataRequestsWithdraw(PsycopgResource):
+
+    @endpoint_info_2(
+        namespace=namespace_data_requests,
+        auth_info=STANDARD_JWT_AUTH_INFO,
+        schema_config=SchemaConfigs.DATA_REQUESTS_BY_ID_WITHDRAW,
+        response_info=ResponseInfo(
+            success_message="Data request successfully withdrawn.",
+        )
+    )
+    def post(self, resource_id: str, access_info: AccessInfo) -> Response:
+        """
+        Withdraw a data request
+        """
+        return self.run_endpoint(
+            wrapper_function=withdraw_data_request_wrapper,
+            data_request_id=int(resource_id),
+            access_info=access_info,
+        )
+
 
 
 @namespace_data_requests.route("/<resource_id>/related-locations")

--- a/resources/endpoint_schema_config.py
+++ b/resources/endpoint_schema_config.py
@@ -177,6 +177,10 @@ class SchemaConfigs(Enum):
         input_dto_class=DataRequestsPutOuterDTO,
         primary_output_schema=MessageSchema(),
     )
+    DATA_REQUESTS_BY_ID_WITHDRAW = EndpointSchemaConfig(
+        input_schema=GetByIDBaseSchema(),
+        primary_output_schema=MessageSchema(),
+    )
     DATA_REQUESTS_POST = EndpointSchemaConfig(
         input_schema=DataRequestsPostSchema(),
         input_dto_class=DataRequestsPostDTO,

--- a/tests/helper_scripts/helper_classes/RequestValidator.py
+++ b/tests/helper_scripts/helper_classes/RequestValidator.py
@@ -298,3 +298,31 @@ class RequestValidator:
             expected_schema=SchemaConfigs.DATA_REQUESTS_GET_MANY.value.primary_output_schema
         )
 
+    def withdraw_request(
+            self,
+            data_request_id: int,
+            headers: dict,
+            expected_response_status: HTTPStatus = HTTPStatus.OK
+    ):
+        return self.post(
+            endpoint="/api/data-requests/{data_request_id}/withdraw".format(
+                data_request_id=data_request_id),
+            headers=headers,
+            expected_response_status=expected_response_status,
+            expected_schema=SchemaConfigs.DATA_REQUESTS_BY_ID_WITHDRAW.value.primary_output_schema
+        )
+
+    def get_data_request_by_id(
+            self,
+            data_request_id: int,
+            headers: dict,
+            expected_response_status: HTTPStatus = HTTPStatus.OK,
+            expected_schema=SchemaConfigs.DATA_REQUESTS_BY_ID_GET.value.primary_output_schema
+    ):
+        return self.get(
+            endpoint=DATA_REQUESTS_BY_ID_ENDPOINT.format(
+                data_request_id=data_request_id),
+            headers=headers,
+            expected_response_status=expected_response_status,
+            expected_schema=expected_schema
+        )


### PR DESCRIPTION
#### Fixes

* https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/411

#### Description

* Add `/data-requests/{data_request_id}/withdraw` endpoint and associated test and document

#### Testing

- Run tests in `tests` directory, and confirm all function as expected
- Inspect API and confirm presence of expected changes.

#### Performance

* Increased test overhead
* New endpoint, obviously

#### Docs

* Endpoint documentation created

#### Breaking Changes

* No breaking changes