### PR TITLE
Move data sources map endpoint to `/map/data-sources`

### DIFF
--- a/app.py
+++ b/app.py
@@ -12,6 +12,7 @@ from resources.GithubDataRequests import namespace_github
 from resources.HomepageSearchCache import namespace_homepage_search_cache
 from resources.LinkToGithub import namespace_link_to_github
 from resources.LoginWithGithub import namespace_login_with_github
+from resources.Map import namespace_map
 from resources.Notifications import namespace_notifications
 from resources.OAuth import namespace_oauth
 from resources.Permissions import namespace_permissions
@@ -63,6 +64,7 @@ NAMESPACES = [
     namespace_user,
     namespace_github,
     namespace_notifications,
+    namespace_map,
 ]
 
 MY_PREFIX = "/api"

--- a/resources/DataSources.py
+++ b/resources/DataSources.py
@@ -48,34 +48,6 @@ namespace_data_source = create_namespace(AppNamespaces.DATA_SOURCES)
     # But we have not yet decided whether to modify or remove it entirely
 
 
-@namespace_data_source.route("/data-sources-map")
-class DataSourcesMap(PsycopgResource):
-    """
-    A resource for managing collections of data sources for mapping.
-    Provides a method for retrieving all data sources.
-    """
-
-    @endpoint_info_2(
-        namespace=namespace_data_source,
-        auth_info=GET_AUTH_INFO,
-        schema_config=SchemaConfigs.DATA_SOURCES_MAP,
-        response_info=ResponseInfo(
-            success_message="Returns all requested data sources.",
-        ),
-        description="Retrieves location-relevant columns for data sources.",
-
-    )
-    def get(self, access_info: AccessInfo) -> Response:
-        """
-        Retrieves location relevant columns for data sources.
-
-        Returns:
-        - A dictionary containing the count of data sources and their details.
-        """
-        return self.run_endpoint(get_data_sources_for_map_wrapper)
-
-
-
 @namespace_data_source.route("/<resource_id>")
 class DataSourceById(PsycopgResource):
     """

--- a/resources/Map.py
+++ b/resources/Map.py
@@ -1,0 +1,37 @@
+from flask import Response
+
+from middleware.access_logic import GET_AUTH_INFO, AccessInfo
+from middleware.decorators import endpoint_info_2
+from middleware.primary_resource_logic.data_sources_logic import get_data_sources_for_map_wrapper
+from resources.PsycopgResource import PsycopgResource
+from resources.endpoint_schema_config import SchemaConfigs
+from resources.resource_helpers import ResponseInfo
+from utilities.namespace import AppNamespaces, create_namespace
+
+namespace_map = create_namespace(AppNamespaces.MAP)
+
+@namespace_map.route("/data-sources")
+class DataSourcesMap(PsycopgResource):
+    """
+    A resource for managing collections of data sources for mapping.
+    Provides a method for retrieving all data sources.
+    """
+
+    @endpoint_info_2(
+        namespace=namespace_map,
+        auth_info=GET_AUTH_INFO,
+        schema_config=SchemaConfigs.DATA_SOURCES_MAP,
+        response_info=ResponseInfo(
+            success_message="Returns all requested data sources.",
+        ),
+        description="Retrieves location-relevant columns for data sources.",
+
+    )
+    def get(self, access_info: AccessInfo) -> Response:
+        """
+        Retrieves location relevant columns for data sources.
+
+        Returns:
+        - A dictionary containing the count of data sources and their details.
+        """
+        return self.run_endpoint(get_data_sources_for_map_wrapper)

--- a/tests/integration/test_data_sources_map.py
+++ b/tests/integration/test_data_sources_map.py
@@ -19,7 +19,7 @@ def test_data_sources_map_get(
     tdc = test_data_creator_flask
     tus = tdc.standard_user()
     response_json = tdc.request_validator.get(
-        endpoint="/api/data-sources/data-sources-map",
+        endpoint="/api/map/data-sources",
         headers=tus.api_authorization_header,
         expected_schema=SchemaConfigs.DATA_SOURCES_MAP.value.primary_output_schema,
     )


### PR DESCRIPTION
### Fixes

*  https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/438

### Description

* Move data sources map endpoint to `/map/data-sources`

### Testing

- Run tests in `tests` directory, and confirm all function as expected
- Inspect API and confirm presence of expected changes.

### Performance

* No performance impact

### Docs

* Documentation for endpoint now properly appears 

### Breaking Changes

* `/data-sources/data-sources-map` endpoint has been moved to `/map/data-sources`
