### PR TITLE
Refactor reset tokens to use `user_id` rather than `email` as user identifier.

### DIFF
--- a/database_client/database_client.py
+++ b/database_client/database_client.py
@@ -199,7 +199,7 @@ class DatabaseClient:
             id_column_name="email",
         )
 
-    ResetTokenInfo = namedtuple("ResetTokenInfo", ["id", "email", "create_date"])
+    ResetTokenInfo = namedtuple("ResetTokenInfo", ["id", "user_id", "create_date"])
 
     def get_reset_token_info(self, token: str) -> Optional[ResetTokenInfo]:
         """
@@ -210,17 +210,17 @@ class DatabaseClient:
         """
         results = self._select_from_relation(
             relation_name="reset_tokens",
-            columns=["id", "email", "create_date"],
+            columns=["id", "user_id", "create_date"],
             where_mappings=[WhereMapping(column="token", value=token)],
         )
         if len(results) == 0:
             return None
         row = results[0]
         return self.ResetTokenInfo(
-            id=row["id"], email=row["email"], create_date=row["create_date"]
+            id=row["id"], user_id=row["user_id"], create_date=row["create_date"]
         )
 
-    def add_reset_token(self, email: str, token: str):
+    def add_reset_token(self, user_id: int, token: str):
         """
         Inserts a new reset token into the database for a specified email.
 
@@ -229,11 +229,11 @@ class DatabaseClient:
         """
         self._create_entry_in_table(
             table_name="reset_tokens",
-            column_value_mappings={"email": email, "token": token},
+            column_value_mappings={"user_id": user_id, "token": token},
         )
 
     @cursor_manager()
-    def delete_reset_token(self, email: str, token: str):
+    def delete_reset_token(self, user_id: int, token: str):
         """
         Deletes a reset token from the database for a specified email.
 
@@ -241,8 +241,8 @@ class DatabaseClient:
         :param token: The reset token to delete.
         """
         query = sql.SQL(
-            "delete from reset_tokens where email = {} and token = {}"
-        ).format(sql.Literal(email), sql.Literal(token))
+            "delete from reset_tokens where user_id = {} and token = {}"
+        ).format(sql.Literal(user_id), sql.Literal(token))
         self.cursor.execute(query)
 
     UserIdentifiers = namedtuple("UserIdentifiers", ["id", "email"])

--- a/database_client/models.py
+++ b/database_client/models.py
@@ -587,7 +587,7 @@ class ResetToken(Base):
     __tablename__ = Relations.RESET_TOKENS.value
 
     id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
-    email: Mapped[Optional[text]]
+    user_id: Mapped[int] = mapped_column(ForeignKey("public.users.id"))
     token: Mapped[Optional[text]]
     create_date: Mapped[timestamp] = mapped_column(
         server_default=func.current_timestamp()

--- a/middleware/access_logic.py
+++ b/middleware/access_logic.py
@@ -83,8 +83,10 @@ class AccessInfo:
         return db_client.get_user_id(self.user_email)
 
 @dataclass
-class PasswordResetTokenAccessInfo(AccessInfo):
-    reset_token: str = ""
+class PasswordResetTokenAccessInfo:
+    user_id: int
+    reset_token: str
+    access_type = AccessTypeEnum.RESET_PASSWORD
 
 
 def get_identity_from_jwt() -> Optional[dict]:
@@ -108,8 +110,7 @@ def get_password_reset_access_info_from_jwt() -> Optional[PasswordResetTokenAcce
         purpose=JWTPurpose.PASSWORD_RESET
     )
     return PasswordResetTokenAccessInfo(
-        user_email=decoded_jwt.sub["email"],
-        access_type=AccessTypeEnum.RESET_PASSWORD,
+        user_id=decoded_jwt.sub["user_id"],
         reset_token=decoded_jwt.sub["token"],
     )
 

--- a/middleware/primary_resource_logic/user_queries.py
+++ b/middleware/primary_resource_logic/user_queries.py
@@ -36,7 +36,7 @@ class UserRequestDTO:
     password: str
 
 
-def user_check_email(db_client: DatabaseClient, email: str) -> None:
+def user_check_email(db_client: DatabaseClient, email: str) -> int:
     """
     Checks if a user with the given email exists in the database, raising an error if not.
 
@@ -47,6 +47,7 @@ def user_check_email(db_client: DatabaseClient, email: str) -> None:
     user_id = db_client.get_user_id(email)
     if user_id is None:
         raise UserNotFoundError(email)
+    return user_id
 
 
 def user_post_results(db_client: DatabaseClient, dto: UserRequestDTO) -> Response:

--- a/tests/integration/test_request_reset_password.py
+++ b/tests/integration/test_request_reset_password.py
@@ -33,14 +33,14 @@ def test_request_reset_password_post(test_data_creator_flask: TestDataCreatorFla
     db_client = DatabaseClient()
     rows = db_client.execute_raw_sql(
         """
-    SELECT email FROM reset_tokens where token = %s
+    SELECT user_id FROM reset_tokens where token = %s
     """,
         (decoded_token.sub["token"],),
     )
     assert (
         len(rows) == 1
     ), "Only one row should have a reset token associated with this email"
-    email = rows[0]["email"]
+    user_id = rows[0]["user_id"]
     assert (
-        email == user_info.email
+        user_id == user_info.user_id
     ), "Email associated with reset token should match the user's email"

--- a/tests/test_database_client.py
+++ b/tests/test_database_client.py
@@ -157,13 +157,13 @@ def test_set_user_password_digest(live_database_client: DatabaseClient):
 def test_reset_token_logic(live_database_client: DatabaseClient):
     fake_email = get_test_name()
     fake_token = uuid.uuid4().hex
-    live_database_client.create_new_user(fake_email, "test_password")
-    live_database_client.add_reset_token(fake_email, fake_token)
+    user_id = live_database_client.create_new_user(fake_email, "test_password")
+    live_database_client.add_reset_token(user_id, fake_token)
     reset_token_info = live_database_client.get_reset_token_info(fake_token)
     assert reset_token_info, "Token not found"
-    assert reset_token_info.email == fake_email, "Email does not match"
+    assert reset_token_info.user_id == user_id, "User id does not match"
 
-    live_database_client.delete_reset_token(fake_email, fake_token)
+    live_database_client.delete_reset_token(user_id, fake_token)
     reset_token_info = live_database_client.get_reset_token_info(fake_token)
     assert reset_token_info is None, "Token not deleted"
 


### PR DESCRIPTION
### Fixes

* https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/277

### Description

* Refactor reset tokens to use `user_id` rather than `email` as user identifier
* Update associated tests

### Testing

* Run tests in tests directory, and confirm all function as expected

### Performance

* Impact marginal

### Docs

* No changes to documentation

### Breaking Changes

* No breaking changes. 