### PR TITLE
Update request reset password message

### DIFF
--- a/resources/RequestResetPassword.py
+++ b/resources/RequestResetPassword.py
@@ -1,5 +1,4 @@
 from flask import request, Response
-from flask_restx import fields
 
 from middleware.access_logic import NO_AUTH_INFO, AccessInfo
 from middleware.decorators import endpoint_info_2

--- a/tests/helper_scripts/helper_classes/RequestValidator.py
+++ b/tests/helper_scripts/helper_classes/RequestValidator.py
@@ -136,7 +136,11 @@ class RequestValidator:
         )
 
     def request_reset_password(
-        self, email: str, mocker, expected_response_status: HTTPStatus = HTTPStatus.OK
+        self,
+        email: str,
+        mocker,
+        expect_call: bool = True,
+        expected_response_status: HTTPStatus = HTTPStatus.OK
     ):
         mock = mocker.patch(
             "middleware.primary_resource_logic.reset_token_queries.send_password_reset_link"
@@ -145,7 +149,12 @@ class RequestValidator:
             endpoint="/api/request-reset-password",
             json={"email": email},
             expected_response_status=expected_response_status,
+            expected_schema=SchemaConfigs.REQUEST_RESET_PASSWORD.value.primary_output_schema,
         )
+        if not expect_call:
+            assert not mock.called
+            return
+        assert mock.call_args[1]["email"] == email
         return mock.call_args[1]["token"]
 
     def reset_token_validation(

--- a/tests/integration/test_request_reset_password.py
+++ b/tests/integration/test_request_reset_password.py
@@ -19,19 +19,13 @@ def test_request_reset_password_post(
 
     user_info = tdc.standard_user().user_info
 
-    mock_send_password_reset_link = mocker.patch(
-        "middleware.primary_resource_logic.reset_token_queries.send_password_reset_link"
-    )
-    tdc.request_validator.post(
-        endpoint="/api/request-reset-password",
-        json={"email": user_info.email},
-        expected_schema=SchemaConfigs.REQUEST_RESET_PASSWORD.value.primary_output_schema,
+    token = tdc.request_validator.request_reset_password(
+        email=user_info.email,
+        mocker=mocker,
     )
 
-    reset_token = mock_send_password_reset_link.call_args[1]["token"]
-    assert mock_send_password_reset_link.call_args[1]["email"] == user_info.email
     decoded_token = SimpleJWT.decode(
-        token=reset_token, purpose=JWTPurpose.PASSWORD_RESET
+        token=token, purpose=JWTPurpose.PASSWORD_RESET
     )
 
     db_client = DatabaseClient()
@@ -44,7 +38,18 @@ def test_request_reset_password_post(
     assert (
         len(rows) == 1
     ), "Only one row should have a reset token associated with this email"
+
     user_id = rows[0]["user_id"]
     assert (
         user_id == user_info.user_id
     ), "Email associated with reset token should match the user's email"
+
+def test_request_password_reset_invalid_email(test_data_creator_flask: TestDataCreatorFlask, mocker):
+    tdc = test_data_creator_flask
+
+    token = tdc.request_validator.request_reset_password(
+        email="email_does_not_exist",
+        mocker=mocker,
+        expect_call=False
+    )
+


### PR DESCRIPTION
### Fixes

* https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/520

### Description

* Update password request message to be more ambiguous about whether or not an email was sent
* Update password request logic to not break if an email was not found, and to send the same response

### Testing

* Run tests in tests directory, and confirm all function as expected

### Performance

* Impact marginal

### Docs

* No change to documentation

### Breaking Changes

* No breaking changes.