### PR TITLE
Update Change Password Endpoint

### DIFF
--- a/database_client/database_client.py
+++ b/database_client/database_client.py
@@ -196,6 +196,15 @@ class DatabaseClient:
             id_column_name="id",
         )
 
+    def get_password_digest(self, user_id: int) -> str:
+        return self._select_single_entry_from_relation(
+            relation_name=Relations.USERS.value,
+            columns=["password_digest"],
+            where_mappings={
+                "id": user_id,
+            },
+        )["password_digest"]
+
     def password_digest_matches(self, user_id: int, password_digest: str) -> bool:
         db_password_digest = self._select_single_entry_from_relation(
             relation_name=Relations.USERS.value,

--- a/database_client/database_client.py
+++ b/database_client/database_client.py
@@ -196,6 +196,16 @@ class DatabaseClient:
             id_column_name="id",
         )
 
+    def password_digest_matches(self, user_id: int, password_digest: str) -> bool:
+        db_password_digest = self._select_single_entry_from_relation(
+            relation_name=Relations.USERS.value,
+            columns=["password_digest"],
+            where_mappings={
+                "id": user_id,
+            },
+        )["password_digest"]
+        return password_digest == db_password_digest
+
     ResetTokenInfo = namedtuple("ResetTokenInfo", ["id", "user_id", "create_date"])
 
     def get_reset_token_info(self, token: str) -> Optional[ResetTokenInfo]:

--- a/database_client/models.py
+++ b/database_client/models.py
@@ -250,10 +250,6 @@ class Agency(Base, CountMetadata):
 class AgencyExpanded(Agency):
 
     __tablename__ = Relations.AGENCIES_EXPANDED.value
-    __table_args__ = {
-        "polymorphic_identity": "agency_expanded",
-        "inherit_conditions": (Agency.id == id),
-    }
     id = mapped_column(None, ForeignKey("public.agencies.id"), primary_key=True)
 
     state_name = Column(String)  #
@@ -514,10 +510,6 @@ class DataSourceExpanded(DataSource):
     id = mapped_column(None, ForeignKey("public.data_sources.id"), primary_key=True)
 
     __tablename__ = Relations.DATA_SOURCES_EXPANDED.value
-    __table_args__ = {
-        "polymorphic_identity": "data_source_expanded",
-        "inherit_conditions": (DataSource.id == id),
-    }
 
     record_type_name: Mapped[Optional[str]]
 

--- a/middleware/schema_and_dto_logic/primary_resource_dtos/user_profile_dtos.py
+++ b/middleware/schema_and_dto_logic/primary_resource_dtos/user_profile_dtos.py
@@ -1,0 +1,7 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class UserPutDTO:
+    old_password: str
+    new_password: str

--- a/middleware/schema_and_dto_logic/primary_resource_schemas/user_profile_schemas.py
+++ b/middleware/schema_and_dto_logic/primary_resource_schemas/user_profile_schemas.py
@@ -12,6 +12,17 @@ from middleware.schema_and_dto_logic.util import get_json_metadata
 from utilities.enums import RecordCategories
 
 
+class UserPutSchema(Schema):
+    old_password = fields.Str(
+        required=True,
+        metadata=get_json_metadata("The old password of the user"),
+    )
+    new_password = fields.Str(
+        required=True,
+        metadata=get_json_metadata("The new password of the user"),
+    )
+
+
 class GetUserRecentSearchesInnerSchema(Schema):
     state_iso = fields.Str(
         required=True,

--- a/resources/User.py
+++ b/resources/User.py
@@ -60,30 +60,3 @@ class User(PsycopgResource):
                 dto_class=UserRequestDTO,
             ),
         )
-
-    @endpoint_info_2(
-        namespace=namespace_user_old,
-        auth_info=STANDARD_JWT_AUTH_INFO,
-        schema_config=SchemaConfigs.USER_PUT,
-        response_info=ResponseInfo(
-            response_dictionary={
-                200: "Success: User password successfully updated",
-                500: "Error: Internal server error",
-            }
-        ),
-    )
-    def put(self, access_info: AccessInfoPrimary) -> Response:
-        """
-        Allows an existing user to update their password.
-
-        The user's new password is hashed and updated in the database based on their email.
-        Upon successful password update, a message is returned to the user.
-
-        Returns:
-        - A dictionary containing a success message or an error message if the operation fails.
-        """
-        return self.run_endpoint(
-            wrapper_function=change_password_wrapper,
-            schema_populate_parameters=SchemaConfigs.USER_PUT.value.get_schema_populate_parameters(),
-            access_info=access_info,
-        )

--- a/resources/User.py
+++ b/resources/User.py
@@ -2,7 +2,12 @@ from http import HTTPStatus
 
 from flask import Response
 
-from middleware.primary_resource_logic.reset_token_queries import set_user_password
+from middleware.access_logic import STANDARD_JWT_AUTH_INFO, AccessInfoPrimary
+from middleware.decorators import endpoint_info_2
+from middleware.primary_resource_logic.reset_token_queries import (
+    set_user_password,
+    change_password_wrapper,
+)
 from middleware.primary_resource_logic.user_queries import (
     user_post_results,
     UserRequestDTO,
@@ -11,26 +16,24 @@ from middleware.primary_resource_logic.user_queries import (
 from typing import Dict, Any
 
 from middleware.schema_and_dto_logic.non_dto_dataclasses import SchemaPopulateParameters
-from resources.resource_helpers import add_api_key_header_arg
+from resources.endpoint_schema_config import SchemaConfigs
+from resources.resource_helpers import ResponseInfo
 from middleware.schema_and_dto_logic.dynamic_logic.model_helpers_with_schemas import (
     create_user_model,
 )
-from utilities.namespace import create_namespace
+from utilities.namespace import create_namespace, AppNamespaces
 from resources.PsycopgResource import PsycopgResource, handle_exceptions
 from middleware.schema_and_dto_logic.dynamic_logic.dynamic_schema_request_content_population import (
     populate_schema_with_request_content,
 )
 
-namespace_user_old = create_namespace()
+namespace_user_old = create_namespace(AppNamespaces.USER)
 
 # Define the user model for request parsing and validation
 user_model = create_user_model(namespace_user_old)
 
-authorization_parser = namespace_user_old.parser()
-add_api_key_header_arg(authorization_parser)
 
-
-@namespace_user_old.route("/user")
+@namespace_user_old.route("")
 class User(PsycopgResource):
     """
     A resource for user management, allowing new users to sign up and existing users to update their passwords.
@@ -58,15 +61,18 @@ class User(PsycopgResource):
             ),
         )
 
-    # Endpoint for updating a user's password
-    @handle_exceptions
-    @namespace_user_old.expect(authorization_parser, user_model)
-    @namespace_user_old.response(201, "Success: User password successfully updated")
-    @namespace_user_old.response(500, "Error: Internal server error")
-    @namespace_user_old.doc(
-        description="Update user password.",
+    @endpoint_info_2(
+        namespace=namespace_user_old,
+        auth_info=STANDARD_JWT_AUTH_INFO,
+        schema_config=SchemaConfigs.USER_PUT,
+        response_info=ResponseInfo(
+            response_dictionary={
+                200: "Success: User password successfully updated",
+                500: "Error: Internal server error",
+            }
+        ),
     )
-    def put(self) -> Dict[str, Any]:
+    def put(self, access_info: AccessInfoPrimary) -> Response:
         """
         Allows an existing user to update their password.
 
@@ -76,14 +82,8 @@ class User(PsycopgResource):
         Returns:
         - A dictionary containing a success message or an error message if the operation fails.
         """
-        dto = populate_schema_with_request_content(
-            schema=UserRequestSchema(),
-            dto_class=UserRequestDTO,
+        return self.run_endpoint(
+            wrapper_function=change_password_wrapper,
+            schema_populate_parameters=SchemaConfigs.USER_PUT.value.get_schema_populate_parameters(),
+            access_info=access_info,
         )
-        with self.setup_database_client() as db_client:
-            set_user_password(
-                db_client=db_client,
-                user_id=db_client.get_user_info(dto.email).id,
-                password=dto.password,
-            )
-        return {"message": "Successfully updated password"}, HTTPStatus.OK

--- a/resources/UserProfile.py
+++ b/resources/UserProfile.py
@@ -42,7 +42,7 @@ user_data_requests_model = get_restx_param_documentation(
 ).model
 
 
-@namespace_user.route("/update-password")
+@namespace_user.route("/<user_id>/update-password")
 class UserUpdatePassword(PsycopgResource):
 
     @endpoint_info_2(
@@ -56,7 +56,7 @@ class UserUpdatePassword(PsycopgResource):
             }
         ),
     )
-    def post(self, access_info: AccessInfoPrimary) -> Response:
+    def post(self, access_info: AccessInfoPrimary, user_id: int) -> Response:
         """
         Allows an existing user to update their password.
 
@@ -70,6 +70,7 @@ class UserUpdatePassword(PsycopgResource):
             wrapper_function=change_password_wrapper,
             schema_populate_parameters=SchemaConfigs.USER_PUT.value.get_schema_populate_parameters(),
             access_info=access_info,
+            user_id=user_id,
         )
 
 

--- a/resources/endpoint_schema_config.py
+++ b/resources/endpoint_schema_config.py
@@ -21,6 +21,9 @@ from middleware.primary_resource_logic.reset_token_queries import (
 from middleware.schema_and_dto_logic.primary_resource_dtos.request_reset_password_dtos import (
     RequestResetPasswordRequestDTO,
 )
+from middleware.schema_and_dto_logic.primary_resource_dtos.user_profile_dtos import (
+    UserPutDTO,
+)
 from middleware.schema_and_dto_logic.primary_resource_schemas.refresh_session_schemas import (
     RefreshSessionRequestSchema,
     RefreshSessionRequestDTO,
@@ -154,6 +157,7 @@ from middleware.schema_and_dto_logic.primary_resource_schemas.github_issue_app_s
 from middleware.schema_and_dto_logic.primary_resource_schemas.user_profile_schemas import (
     GetUserRecentSearchesOuterSchema,
     UserProfileResponseSchema,
+    UserPutSchema,
 )
 
 
@@ -370,6 +374,11 @@ class SchemaConfigs(Enum):
         primary_output_schema=NotificationsResponseSchema(),
     )
     # region User Profile
+    USER_PUT = EndpointSchemaConfig(
+        input_schema=UserPutSchema(),
+        input_dto_class=UserPutDTO,
+        primary_output_schema=MessageSchema(),
+    )
     USER_PROFILE_RECENT_SEARCHES = EndpointSchemaConfig(
         primary_output_schema=GetUserRecentSearchesOuterSchema(exclude=["message"]),
     )

--- a/tests/helper_scripts/helper_classes/RequestValidator.py
+++ b/tests/helper_scripts/helper_classes/RequestValidator.py
@@ -437,3 +437,17 @@ class RequestValidator:
             headers=headers,
             expected_schema=SchemaConfigs.AGENCIES_GET_MANY.value.primary_output_schema,
         )
+
+    def update_password(
+        self,
+        headers: dict,
+        old_password: str,
+        new_password: str,
+        expected_response_status: HTTPStatus = HTTPStatus.OK,
+    ):
+        return self.post(
+            endpoint="/api/user/change-password",
+            headers=headers,
+            json={"old_password": old_password, "new_password": new_password},
+            expected_response_status=expected_response_status,
+        )

--- a/tests/helper_scripts/helper_classes/RequestValidator.py
+++ b/tests/helper_scripts/helper_classes/RequestValidator.py
@@ -441,12 +441,13 @@ class RequestValidator:
     def update_password(
         self,
         headers: dict,
+        user_id: int,
         old_password: str,
         new_password: str,
         expected_response_status: HTTPStatus = HTTPStatus.OK,
     ):
         return self.post(
-            endpoint="/api/user/change-password",
+            endpoint=f"/api/user/{user_id}/update-password",
             headers=headers,
             json={"old_password": old_password, "new_password": new_password},
             expected_response_status=expected_response_status,

--- a/tests/helper_scripts/helper_functions.py
+++ b/tests/helper_scripts/helper_functions.py
@@ -249,7 +249,7 @@ def create_test_user_api(client: FlaskClient) -> UserInfo:
     email = get_test_email()
     password = str(uuid.uuid4())
     response = client.post(
-        "user",
+        "/api/user",
         json={"email": email, "password": password},
     )
     user_id = DatabaseClient().get_user_id(email)

--- a/tests/integration/test_user.py
+++ b/tests/integration/test_user.py
@@ -61,24 +61,31 @@ def test_user_post_user_already_exists(
     )
 
 
-def test_user_put(flask_client_with_db):
+def test_user_put(
+    test_data_creator_flask: TestDataCreatorFlask,
+):
     """
     Test that PUT call to /user endpoint successfully updates the user's password and verifies the new password hash is distinct from both the plain new password and the old password hash in the database
     """
+    tdc = test_data_creator_flask
 
-    tus = create_test_user_setup(flask_client_with_db)
+    tus = tdc.standard_user()
     old_password_hash = get_user_password_digest(tus.user_info)
 
     new_password = str(uuid.uuid4())
 
     # Try to update password with incorrect old password and fail
-    pytest.fail("Not implemented")
-
-    # TODO: Convert to RequestValidate
-    response = flask_client_with_db.put(
-        "/api/user",
+    tdc.request_validator.update_password(
         headers=tus.jwt_authorization_header,
-        json={"old_password": tus.user_info.password, "new_password": new_password},
+        old_password="gibberish",
+        new_password=new_password,
+        expected_response_status=HTTPStatus.UNAUTHORIZED,
+    )
+
+    response = tdc.request_validator.update_password(
+        headers=tus.jwt_authorization_header,
+        old_password=tus.user_info.password,
+        new_password=new_password,
     )
     assert (
         response.status_code == HTTPStatus.OK.value

--- a/tests/integration/test_user.py
+++ b/tests/integration/test_user.py
@@ -3,6 +3,8 @@
 from http import HTTPStatus
 import uuid
 
+import pytest
+
 from database_client.database_client import DatabaseClient
 from tests.conftest import flask_client_with_db
 from tests.helper_scripts.helper_classes.TestDataCreatorFlask import (
@@ -69,10 +71,14 @@ def test_user_put(flask_client_with_db):
 
     new_password = str(uuid.uuid4())
 
+    # Try to update password with incorrect old password and fail
+    pytest.fail("Not implemented")
+
+    # TODO: Convert to RequestValidate
     response = flask_client_with_db.put(
         "/api/user",
-        headers=tus.api_authorization_header,
-        json={"email": tus.user_info.email, "password": new_password},
+        headers=tus.jwt_authorization_header,
+        json={"old_password": tus.user_info.password, "new_password": new_password},
     )
     assert (
         response.status_code == HTTPStatus.OK.value

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -84,7 +84,7 @@ def check_method_exists(class_type, client, endpoint, method):
 
 TestParameters = namedtuple("Resource", ["class_type", "endpoint", "allowed_methods"])
 test_parameters = [
-    TestParameters(User, "/user", [POST, PUT]),
+    TestParameters(User, "/user", [POST]),
     TestParameters(Login, "/login", [POST]),
     TestParameters(RefreshSession, "/refresh-session", [POST]),
     TestParameters(ApiKeyResource, f"/auth{API_KEY_ROUTE}", [POST]),


### PR DESCRIPTION
### Fixes

* https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/539

### Description

* Changes password reset functionality from `/user` `PUT` to `/user/change-password` `POST`
* Replace previous API key header requirement with a JWT header requirement, ensuring users are logged in when they perform the action
* Updates password functionality to require the original password to be provided in addition to the new, and remove the need for email to be included in the json body (since that information is conveyed by the JWT)
* Updates test logic and documentation accordingly 

### Testing

- Run tests in `tests` directory, and confirm all function as expected
- Inspect API and confirm presence of expected changes.

### Performance

* Additional overhead to password updating endpoint

### Docs

* API documentation is updated to reflect the above changes.

### Breaking Changes

@joshuagraber 
* Endpoint changed from `/user` `PUT` to `/user/<user_id>/update-password` `POST`
* The endpoint will now accept a JWT as a token, rather than an API key
* Instead of inputting the email and new password in the json body, the new and old password will be input in the following format:
```
{
  new_password: str,
  old_password: str
}
```
