### PR TITLE
Add logic to automatically indicate when an endpoint requires Admin permissions.

### DIFF
--- a/middleware/access_logic.py
+++ b/middleware/access_logic.py
@@ -32,6 +32,11 @@ class AuthenticationInfo(BaseModel):
     no_auth: bool = False
     restrict_to_permissions: Optional[list[PermissionsEnum]] = None
 
+    def requires_admin_permissions(self) -> bool:
+        if self.restrict_to_permissions is None:
+            return False
+        return len(self.restrict_to_permissions) > 0
+
 
 WRITE_ONLY_AUTH_INFO = AuthenticationInfo(
     allowed_access_methods=[AccessTypeEnum.JWT],


### PR DESCRIPTION
### Fixes

* https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/546

### Description

* Add logic to automatically indicate when an endpoint requires Admin permissions.

### Testing

* Confirm presence of following changes to endpoint documentation requiring admin permissions:
![image](https://github.com/user-attachments/assets/43f4fe11-bdf3-491a-9393-c1dd0a268ecd)

### Performance

* Impact marginal

### Docs

* API documentation updated as described above.

### Breaking Changes

* No breaking changes.