### PR TITLE
Work `/api-key` to accept JWT authorization rather than email and login.

### DIFF
--- a/resources/ApiKeyResource.py
+++ b/resources/ApiKeyResource.py
@@ -2,7 +2,11 @@ from http import HTTPStatus
 
 from flask import Response
 
-from middleware.access_logic import NO_AUTH_INFO, AccessInfoPrimary
+from middleware.access_logic import (
+    NO_AUTH_INFO,
+    AccessInfoPrimary,
+    STANDARD_JWT_AUTH_INFO,
+)
 from middleware.decorators import endpoint_info
 from middleware.primary_resource_logic.api_key_logic import create_api_key_for_user
 
@@ -22,14 +26,10 @@ class ApiKeyResource(PsycopgResource):
 
     @endpoint_info(
         namespace=namespace_api_key,
-        auth_info=NO_AUTH_INFO,
+        auth_info=STANDARD_JWT_AUTH_INFO,
         description="Generates an API key for authenticated users.",
         response_info=ResponseInfo(
-            response_dictionary={
-                HTTPStatus.OK.value: "OK. API key generated.",
-                HTTPStatus.UNAUTHORIZED.value: "Unauthorized. Forbidden or invalid authentication.",
-                HTTPStatus.INTERNAL_SERVER_ERROR.value: "Internal server error.",
-            }
+            success_message="OK. API key generated.",
         ),
         schema_config=SchemaConfigs.API_KEY_POST,
     )
@@ -47,5 +47,5 @@ class ApiKeyResource(PsycopgResource):
         """
         return self.run_endpoint(
             wrapper_function=create_api_key_for_user,
-            schema_populate_parameters=SchemaConfigs.API_KEY_POST.value.get_schema_populate_parameters(),
+            access_info=access_info,
         )

--- a/resources/endpoint_schema_config.py
+++ b/resources/endpoint_schema_config.py
@@ -455,7 +455,7 @@ class SchemaConfigs(Enum):
         input_dto_class=ResetPasswordDTO,
     )
     RESET_TOKEN_VALIDATION = schema_config_with_message_output()
-    API_KEY_POST = get_user_request_endpoint_schema_config(
+    API_KEY_POST = EndpointSchemaConfig(
         primary_output_schema=APIKeyResponseSchema(),
     )
     # endregion

--- a/tests/integration/test_api_key.py
+++ b/tests/integration/test_api_key.py
@@ -4,29 +4,34 @@ from middleware.api_key import ApiKey
 from resources.ApiKeyResource import API_KEY_ROUTE
 from resources.endpoint_schema_config import SchemaConfigs
 from tests.conftest import dev_db_client, flask_client_with_db
+from tests.helper_scripts.helper_classes.TestDataCreatorFlask import (
+    TestDataCreatorFlask,
+)
 from tests.helper_scripts.helper_functions import (
     create_test_user_db_client,
 )
 from tests.helper_scripts.run_and_validate_request import run_and_validate_request
+from conftest import test_data_creator_flask, monkeysession
 
 
-def test_api_key_post(flask_client_with_db, dev_db_client):
+def test_api_key_post(test_data_creator_flask: TestDataCreatorFlask):
     """
     Test that GET call to /api_key endpoint successfully creates an API key and aligns it with the user's API key in the database
     """
+    tdc = test_data_creator_flask
 
-    user_info = create_test_user_db_client(dev_db_client)
+    tus = tdc.standard_user()
 
     response_json = run_and_validate_request(
-        flask_client=flask_client_with_db,
+        flask_client=tdc.flask_client,
         http_method="post",
         endpoint=f"/auth{API_KEY_ROUTE}",
-        json={"email": user_info.email, "password": user_info.password},
+        headers=tus.jwt_authorization_header,
         expected_schema=SchemaConfigs.API_KEY_POST.value.primary_output_schema,
     )
 
     # Check that API key aligned with user
-    new_user_info = dev_db_client.get_user_info(user_info.email)
+    new_user_info = tdc.db_client.get_user_info(tus.user_info.email)
     api_key_raw = response_json.get("api_key")
     api_key = ApiKey(raw_key=api_key_raw)
 


### PR DESCRIPTION
### Fixes

* https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/549

### Description

* Update `/api-key` endpoint to take a JWT authorization header, rather than email and password

### Testing

* Run tests in 
* For cut-and-dry changes (API updates or interface tweaks), include a screenshot or updated API response to show what correct behavior looks like

### Performance

* Impact marginal 

### Docs

* Accompanying docs PRs, if applicable

### Breaking Changes

* `/api-key` endpoint now changed to take a JWT authorization header, rather than email and password.
