### PR TITLE
Reorganize namespaces

### DIFF
--- a/middleware/primary_resource_logic/callback_primary_logic.py
+++ b/middleware/primary_resource_logic/callback_primary_logic.py
@@ -23,7 +23,7 @@ from middleware.custom_dataclasses import (
 from middleware.third_party_interaction_logic.callback_oauth_logic import (
     get_github_oauth_access_token,
 )
-from tests.helper_scripts.helper_functions import add_query_params
+from tests.helper_scripts.helper_functions_simple import add_query_params
 
 
 def get_flask_session_callback_info() -> FlaskSessionCallbackInfo:

--- a/middleware/primary_resource_logic/signup_logic.py
+++ b/middleware/primary_resource_logic/signup_logic.py
@@ -15,7 +15,7 @@ from middleware.primary_resource_logic.user_queries import UserRequestDTO
 from middleware.schema_and_dto_logic.common_schemas_and_dtos import EmailOnlyDTO
 from middleware.third_party_interaction_logic.mailgun_logic import send_via_mailgun
 from middleware.util import create_web_app_url
-from tests.helper_scripts.helper_functions import add_query_params
+from tests.helper_scripts.helper_functions_simple import add_query_params
 
 
 def get_signup_link(token: str):

--- a/middleware/webhook_logic.py
+++ b/middleware/webhook_logic.py
@@ -2,7 +2,7 @@ import requests
 
 from middleware.third_party_interaction_logic.mailgun_logic import send_via_mailgun
 from middleware.util import get_env_variable, create_web_app_url
-from tests.helper_scripts.helper_functions import add_query_params
+from tests.helper_scripts.helper_functions_simple import add_query_params
 
 
 def post_to_webhook(msg: str):

--- a/resources/LinkToGithub.py
+++ b/resources/LinkToGithub.py
@@ -17,7 +17,7 @@ from resources.endpoint_schema_config import SchemaConfigs
 from resources.resource_helpers import ResponseInfo
 from utilities.namespace import create_namespace, AppNamespaces
 
-namespace_link_to_github = create_namespace(AppNamespaces.AUTH)
+namespace_link_to_github = create_namespace(AppNamespaces.OAUTH)
 
 
 @namespace_link_to_github.route("/link-to-github")

--- a/resources/Login.py
+++ b/resources/Login.py
@@ -6,11 +6,11 @@ from middleware.decorators import endpoint_info
 from middleware.primary_resource_logic.login_queries import try_logging_in
 from resources.endpoint_schema_config import SchemaConfigs
 from resources.resource_helpers import ResponseInfo
-from utilities.namespace import create_namespace
+from utilities.namespace import create_namespace, AppNamespaces
 
 from resources.PsycopgResource import PsycopgResource
 
-namespace_login = create_namespace()
+namespace_login = create_namespace(AppNamespaces.AUTH)
 
 
 @namespace_login.route("/login")

--- a/resources/LoginWithGithub.py
+++ b/resources/LoginWithGithub.py
@@ -12,7 +12,7 @@ from resources.endpoint_schema_config import SchemaConfigs
 from resources.resource_helpers import ResponseInfo
 from utilities.namespace import create_namespace, AppNamespaces
 
-namespace_login_with_github = create_namespace(AppNamespaces.AUTH)
+namespace_login_with_github = create_namespace(AppNamespaces.OAUTH)
 
 
 @namespace_login_with_github.route("/login-with-github")

--- a/resources/OAuth.py
+++ b/resources/OAuth.py
@@ -20,10 +20,10 @@ from resources.endpoint_schema_config import SchemaConfigs
 from resources.resource_helpers import ResponseInfo
 from utilities.namespace import create_namespace, AppNamespaces
 
-namespace_oauth = create_namespace(AppNamespaces.AUTH)
+namespace_oauth = create_namespace(AppNamespaces.OAUTH)
 
 
-@namespace_oauth.route("/oauth")
+@namespace_oauth.route("/github")
 class GithubOAuth(PsycopgResource):
 
     @endpoint_info(

--- a/resources/Permissions.py
+++ b/resources/Permissions.py
@@ -24,7 +24,7 @@ from middleware.schema_and_dto_logic.dynamic_logic.dynamic_schema_documentation_
 )
 from middleware.schema_and_dto_logic.non_dto_dataclasses import SchemaPopulateParameters
 
-namespace_permissions = create_namespace(namespace_attributes=AppNamespaces.AUTH)
+namespace_permissions = create_namespace(namespace_attributes=AppNamespaces.PERMISSIONS)
 
 doc_info = get_restx_param_documentation(
     namespace=namespace_permissions,
@@ -37,7 +37,7 @@ all_routes_parser = doc_info.parser
 add_jwt_header_arg(all_routes_parser)
 
 
-@namespace_permissions.route("/permissions")
+@namespace_permissions.route("")
 class Permissions(PsycopgResource):
     """
     Provides a resource for retrieving permissions for a user.

--- a/resources/RefreshSession.py
+++ b/resources/RefreshSession.py
@@ -16,10 +16,10 @@ from middleware.primary_resource_logic.login_queries import (
 from resources.endpoint_schema_config import SchemaConfigs
 from resources.resource_helpers import ResponseInfo
 
-from utilities.namespace import create_namespace
+from utilities.namespace import create_namespace, AppNamespaces
 from resources.PsycopgResource import PsycopgResource, handle_exceptions
 
-namespace_refresh_session = create_namespace()
+namespace_refresh_session = create_namespace(AppNamespaces.AUTH)
 
 
 @namespace_refresh_session.route("/refresh-session")

--- a/resources/RequestResetPassword.py
+++ b/resources/RequestResetPassword.py
@@ -5,11 +5,11 @@ from middleware.decorators import endpoint_info
 from middleware.primary_resource_logic.reset_token_queries import request_reset_password
 from resources.endpoint_schema_config import SchemaConfigs
 from resources.resource_helpers import ResponseInfo
-from utilities.namespace import create_namespace
+from utilities.namespace import create_namespace, AppNamespaces
 
 from resources.PsycopgResource import PsycopgResource, handle_exceptions
 
-namespace_request_reset_password = create_namespace()
+namespace_request_reset_password = create_namespace(AppNamespaces.AUTH)
 
 
 @namespace_request_reset_password.route("/request-reset-password")

--- a/resources/ResetPassword.py
+++ b/resources/ResetPassword.py
@@ -10,11 +10,11 @@ from middleware.primary_resource_logic.reset_token_queries import (
 )
 from resources.endpoint_schema_config import SchemaConfigs
 from resources.resource_helpers import ResponseInfo
-from utilities.namespace import create_namespace
+from utilities.namespace import create_namespace, AppNamespaces
 
 from resources.PsycopgResource import PsycopgResource, handle_exceptions
 
-namespace_reset_password = create_namespace()
+namespace_reset_password = create_namespace(AppNamespaces.AUTH)
 
 
 @namespace_reset_password.route("/reset-password")

--- a/resources/ResetTokenValidation.py
+++ b/resources/ResetTokenValidation.py
@@ -12,10 +12,10 @@ from middleware.primary_resource_logic.reset_token_queries import (
 from resources.endpoint_schema_config import SchemaConfigs
 from resources.resource_helpers import ResponseInfo
 
-from utilities.namespace import create_namespace
+from utilities.namespace import create_namespace, AppNamespaces
 from resources.PsycopgResource import PsycopgResource, handle_exceptions
 
-namespace_reset_token_validation = create_namespace()
+namespace_reset_token_validation = create_namespace(AppNamespaces.AUTH)
 
 
 @namespace_reset_token_validation.route("/reset-token-validation")

--- a/tests/helper_scripts/constants.py
+++ b/tests/helper_scripts/constants.py
@@ -50,9 +50,9 @@ GITHUB_DATA_REQUESTS_ISSUES_ENDPOINT = (
 GITHUB_DATA_REQUESTS_SYNCHRONIZE = "/api/github/data-requests/synchronize"
 
 # region Github OAuth
-GITHUB_OAUTH_LINK_ENDPOINT = "/api/auth/link-to-github"
+GITHUB_OAUTH_LINK_ENDPOINT = "/api/oauth/link-to-github"
 
-GITHUB_OAUTH_LOGIN_ENDPOINT = "/api/auth/login-with-github"
+GITHUB_OAUTH_LOGIN_ENDPOINT = "/api/oauth/login-with-github"
 
 # endregion
 

--- a/tests/helper_scripts/helper_classes/RequestValidator.py
+++ b/tests/helper_scripts/helper_classes/RequestValidator.py
@@ -18,7 +18,7 @@ from tests.helper_scripts.constants import (
     DATA_REQUESTS_BY_ID_ENDPOINT,
     AGENCIES_BASE_ENDPOINT,
 )
-from tests.helper_scripts.helper_functions import (
+from tests.helper_scripts.helper_functions_simple import (
     get_authorization_header,
     add_query_params,
 )
@@ -125,7 +125,7 @@ class RequestValidator:
         expected_schema: Schema = SchemaConfigs.LOGIN_POST.value.primary_output_schema,
     ):
         return self.post(
-            endpoint="/api/login",
+            endpoint="/api/auth/login",
             json={"email": email, "password": password},
             expected_response_status=expected_response_status,
             expected_json_content=expected_json_content,
@@ -139,7 +139,7 @@ class RequestValidator:
         expected_response_status: HTTPStatus = HTTPStatus.OK,
     ):
         return self.post(
-            endpoint="/api/reset-password",
+            endpoint="/api/auth/reset-password",
             headers=get_authorization_header(scheme="Bearer", token=token),
             json={"password": password},
             expected_response_status=expected_response_status,
@@ -156,7 +156,7 @@ class RequestValidator:
             "middleware.primary_resource_logic.reset_token_queries.send_password_reset_link"
         )
         response = self.post(
-            endpoint="/api/request-reset-password",
+            endpoint="/api/auth/request-reset-password",
             json={"email": email},
             expected_response_status=expected_response_status,
             expected_schema=SchemaConfigs.REQUEST_RESET_PASSWORD.value.primary_output_schema,
@@ -232,7 +232,7 @@ class RequestValidator:
         expected_json_content: Optional[dict] = None,
     ):
         return self.post(
-            endpoint="/api/reset-token-validation",
+            endpoint="/api/auth/reset-token-validation",
             headers=get_authorization_header(scheme="Bearer", token=token),
             expected_response_status=expected_response_status,
             expected_json_content=expected_json_content,
@@ -244,7 +244,7 @@ class RequestValidator:
         headers: dict,
         expected_json_content: Optional[dict] = None,
     ):
-        endpoint = f"/auth/permissions?user_email={user_email}"
+        endpoint = f"/permissions?user_email={user_email}"
         return self.get(
             endpoint=endpoint,
             headers=headers,
@@ -258,7 +258,7 @@ class RequestValidator:
         action: str,
         permission: str,
     ):
-        endpoint = f"/auth/permissions?user_email={user_email}"
+        endpoint = f"/permissions?user_email={user_email}"
         return self.put(
             endpoint=endpoint,
             headers=headers,
@@ -540,12 +540,8 @@ class RequestValidator:
         )
 
     def match_agency(
-            self,
-            headers: dict,
-            name: str,
-            state: str,
-            county: str,
-            locality: str):
+        self, headers: dict, name: str, state: str, county: str, locality: str
+    ):
         data = {
             "name": name,
             "state": state,
@@ -555,7 +551,8 @@ class RequestValidator:
             secondary_dict={
                 "county": county,
                 "locality": locality,
-            })
+            },
+        )
         return self.post(
             endpoint="/api/match/agency",
             headers=headers,

--- a/tests/helper_scripts/helper_classes/TestDataCreatorDBClient.py
+++ b/tests/helper_scripts/helper_classes/TestDataCreatorDBClient.py
@@ -17,7 +17,7 @@ from tests.helper_scripts.common_test_data import (
     get_random_number_for_testing,
     get_test_name,
 )
-from tests.helper_scripts.helper_functions import get_notification_valid_date
+from tests.helper_scripts.helper_functions_simple import get_notification_valid_date
 from tests.helper_scripts.test_dataclasses import (
     TestUserDBInfo,
     TestAgencyInfo,

--- a/tests/helper_scripts/helper_classes/TestDataCreatorFlask.py
+++ b/tests/helper_scripts/helper_classes/TestDataCreatorFlask.py
@@ -25,7 +25,7 @@ from tests.helper_scripts.helper_classes.TestDataCreatorDBClient import (
     TestDataCreatorDBClient,
 )
 from tests.helper_scripts.helper_classes.TestUserSetup import TestUserSetup
-from tests.helper_scripts.helper_functions import (
+from tests.helper_scripts.helper_functions_complex import (
     create_admin_test_user_setup,
     create_test_user_setup,
 )

--- a/tests/helper_scripts/helper_functions_simple.py
+++ b/tests/helper_scripts/helper_functions_simple.py
@@ -1,0 +1,40 @@
+from datetime import datetime, timezone, timedelta
+from urllib.parse import urlparse, parse_qs, urlencode, urlunparse
+
+"""
+`Simple` in this case refers to helper functions 
+which rely on no external dependencies
+"""
+
+
+def get_authorization_header(
+    scheme: str,
+    token: str,
+) -> dict:
+    return {"Authorization": f"{scheme} {token}"}
+
+
+def add_query_params(url, params: dict):
+    """
+    Add query parameters to a URL.
+    :param url:
+    :param params:
+    :return:
+    """
+
+    # Parse the original URL into components
+    url_parts = list(urlparse(url))
+
+    # Extract existing query parameters (if any) and update with the new ones
+    query = dict(parse_qs(url_parts[4]))
+    query.update(params)
+
+    # Encode the updated query parameters
+    url_parts[4] = urlencode(query, doseq=True)
+
+    # Rebuild the URL with the updated query parameters
+    return urlunparse(url_parts)
+
+
+def get_notification_valid_date():
+    return datetime.now(timezone.utc) - timedelta(days=30)

--- a/tests/helper_scripts/run_and_validate_request.py
+++ b/tests/helper_scripts/run_and_validate_request.py
@@ -4,7 +4,7 @@ from typing import Optional, Type, Union, Literal, TextIO
 from flask.testing import FlaskClient
 from marshmallow import Schema
 
-from tests.helper_scripts.helper_functions import add_query_params
+from tests.helper_scripts.helper_functions_simple import add_query_params
 from tests.helper_scripts.common_asserts import assert_response_status
 
 http_methods = Literal["get", "post", "put", "patch", "delete"]

--- a/tests/integration/test_api_key.py
+++ b/tests/integration/test_api_key.py
@@ -7,7 +7,7 @@ from tests.conftest import dev_db_client, flask_client_with_db
 from tests.helper_scripts.helper_classes.TestDataCreatorFlask import (
     TestDataCreatorFlask,
 )
-from tests.helper_scripts.helper_functions import (
+from tests.helper_scripts.helper_functions_complex import (
     create_test_user_db_client,
 )
 from tests.helper_scripts.run_and_validate_request import run_and_validate_request

--- a/tests/integration/test_refresh_session.py
+++ b/tests/integration/test_refresh_session.py
@@ -5,7 +5,7 @@ from http import HTTPStatus
 from tests.helper_scripts.helper_classes.TestDataCreatorFlask import (
     TestDataCreatorFlask,
 )
-from tests.helper_scripts.helper_functions import (
+from tests.helper_scripts.helper_functions_complex import (
     login_and_return_jwt_tokens,
 )
 from tests.helper_scripts.run_and_validate_request import run_and_validate_request
@@ -25,7 +25,7 @@ def test_refresh_session_post(test_data_creator_flask: TestDataCreatorFlask):
     run_and_validate_request(
         flask_client=tdc.flask_client,
         http_method="get",
-        endpoint="/auth/permissions?user_email=" + admin_tus.user_info.email,
+        endpoint="/permissions?user_email=" + admin_tus.user_info.email,
         headers={"Authorization": f"Bearer {jwt_tokens.access_token}"},
     )
 
@@ -33,7 +33,7 @@ def test_refresh_session_post(test_data_creator_flask: TestDataCreatorFlask):
     response_json = run_and_validate_request(
         flask_client=tdc.flask_client,
         http_method="post",
-        endpoint="/api/refresh-session",
+        endpoint="/api/auth/refresh-session",
         headers=admin_tus.jwt_authorization_header,
         json={"refresh_token": jwt_tokens.refresh_token},
     )
@@ -53,7 +53,7 @@ def test_refresh_session_post(test_data_creator_flask: TestDataCreatorFlask):
     run_and_validate_request(
         flask_client=tdc.flask_client,
         http_method="get",
-        endpoint="/auth/permissions?user_email=" + admin_tus.user_info.email,
+        endpoint="/permissions?user_email=" + admin_tus.user_info.email,
         headers={"Authorization": f"Bearer {new_access_token}"},
     )
 
@@ -72,7 +72,7 @@ def test_refresh_session_post_invalid_refresh_token(
     response_json = run_and_validate_request(
         flask_client=tdc.flask_client,
         http_method="post",
-        endpoint="/api/refresh-session",
+        endpoint="/api/auth/refresh-session",
         headers=admin_tus.jwt_authorization_header,
         json={"refresh_token": f"{jwt_tokens.refresh_token}"},
         expected_response_status=HTTPStatus.UNAUTHORIZED,

--- a/tests/integration/test_reset_password.py
+++ b/tests/integration/test_reset_password.py
@@ -12,10 +12,10 @@ from tests.helper_scripts.helper_classes.TestDataCreatorFlask import (
 )
 from tests.helper_scripts.constants import DATA_SOURCES_BASE_ENDPOINT
 from tests.helper_scripts.helper_classes.TestUserSetup import TestUserSetup
-from tests.helper_scripts.helper_functions import (
+from tests.helper_scripts.helper_functions_complex import (
     request_reset_password_api,
-    get_authorization_header,
 )
+from tests.helper_scripts.helper_functions_simple import get_authorization_header
 from conftest import test_data_creator_flask, monkeysession
 
 

--- a/tests/integration/test_search.py
+++ b/tests/integration/test_search.py
@@ -16,9 +16,7 @@ from tests.helper_scripts.constants import (
     USER_PROFILE_RECENT_SEARCHES_ENDPOINT,
 )
 from tests.helper_scripts.helper_classes.TestUserSetup import TestUserSetup
-from tests.helper_scripts.helper_functions import (
-    add_query_params,
-)
+from tests.helper_scripts.helper_functions_simple import add_query_params
 from tests.helper_scripts.run_and_validate_request import (
     run_and_validate_request,
     http_methods,

--- a/tests/integration/test_typeahead_suggestions.py
+++ b/tests/integration/test_typeahead_suggestions.py
@@ -5,7 +5,7 @@ from middleware.schema_and_dto_logic.primary_resource_schemas.typeahead_suggesti
 from tests.helper_scripts.helper_classes.TestDataCreatorFlask import (
     TestDataCreatorFlask,
 )
-from tests.helper_scripts.helper_functions import (
+from tests.helper_scripts.helper_functions_complex import (
     setup_get_typeahead_suggestion_test_data,
 )
 from tests.helper_scripts.run_and_validate_request import run_and_validate_request

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -23,7 +23,7 @@ from tests.helper_scripts.common_test_data import get_test_name
 from tests.helper_scripts.helper_classes.TestDataCreatorDBClient import (
     TestDataCreatorDBClient,
 )
-from tests.helper_scripts.helper_functions import get_notification_valid_date
+from tests.helper_scripts.helper_functions_simple import get_notification_valid_date
 from utilities.enums import RecordCategories
 
 ID_COLUMN = "state_iso"

--- a/tests/test_database_client.py
+++ b/tests/test_database_client.py
@@ -52,7 +52,7 @@ from tests.helper_scripts.helper_classes.TestDataCreatorDBClient import (
 )
 from tests.helper_scripts.helper_schemas import TestGetPendingNotificationsOutputSchema
 from tests.helper_scripts.test_dataclasses import TestDataRequestInfo
-from tests.helper_scripts.helper_functions import (
+from tests.helper_scripts.helper_functions_complex import (
     setup_get_typeahead_suggestion_test_data,
     create_test_user_db_client,
 )

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -82,12 +82,12 @@ def check_method_exists(class_type, client, endpoint, method):
 
 TestParameters = namedtuple("Resource", ["class_type", "endpoint", "allowed_methods"])
 test_parameters = [
-    TestParameters(Login, "/login", [POST]),
-    TestParameters(RefreshSession, "/refresh-session", [POST]),
+    TestParameters(Login, "/auth/login", [POST]),
+    TestParameters(RefreshSession, "/auth/refresh-session", [POST]),
     TestParameters(ApiKeyResource, f"/auth{API_KEY_ROUTE}", [POST]),
-    TestParameters(RequestResetPassword, "/request-reset-password", [POST]),
-    TestParameters(ResetPassword, "/reset-password", [POST]),
-    TestParameters(ResetTokenValidation, "/reset-token-validation", [POST]),
+    TestParameters(RequestResetPassword, "auth/request-reset-password", [POST]),
+    TestParameters(ResetPassword, "/auth/reset-password", [POST]),
+    TestParameters(ResetTokenValidation, "/auth/reset-token-validation", [POST]),
     TestParameters(Archives, "/archives", [GET, PUT]),
     TestParameters(DataSources, "/data-sources", [GET, POST]),
     # This endpoint no longer works because of the other data source endpoint
@@ -112,7 +112,7 @@ test_parameters = [
     TestParameters(Search, "/search/search-location-and-record-type", [GET]),
     TestParameters(TypeaheadLocations, "/typeahead/locations", [GET]),
     TestParameters(Callback, "auth/callback", [GET]),
-    TestParameters(Permissions, "auth/permissions", [GET, PUT]),
+    TestParameters(Permissions, "/permissions", [GET, PUT]),
     TestParameters(DataRequests, "/data-requests", [GET, POST]),
     TestParameters(
         DataRequestsById, "/data-requests/<data_request_id>", [GET, PUT, DELETE]

--- a/tests/utilities/test_rate_limiter.py
+++ b/tests/utilities/test_rate_limiter.py
@@ -11,17 +11,9 @@ from tests.helper_scripts.common_asserts import assert_response_status
 
 def post_login_request(client_with_mock_db, ip_address="127.0.0.1"):
     return client_with_mock_db.client.post(
-        "/login",
+        "/auth/login",
         environ_base={"REMOTE_ADDR": ip_address},
         json={"email": "test_email", "password": "test_password"},
-    )
-
-
-def post_refresh_session_request(client_with_mock_db, ip_address="127.0.0.1"):
-    return client_with_mock_db.client.post(
-        "/refresh-session",
-        environ_base={"REMOTE_ADDR": ip_address},
-        json={"refresh_token": "test_refresh_token"},
     )
 
 

--- a/utilities/namespace.py
+++ b/utilities/namespace.py
@@ -9,6 +9,10 @@ class AppNamespaces(Enum):
     DEFAULT = NamespaceAttributes(path="/", description="Default Namespace")
     SEARCH = NamespaceAttributes(path="search", description="Search Namespace")
     AUTH = NamespaceAttributes(path="auth", description="Authentication Namespace")
+    OAUTH = NamespaceAttributes(path="oauth", description="OAuth Namespace")
+    PERMISSIONS = NamespaceAttributes(
+        path="permissions", description="Permissions Namespace"
+    )
     DEV = NamespaceAttributes(path="dev", description="Developer Namespace")
     DATA_REQUESTS = NamespaceAttributes(
         path="data-requests", description="Data Requests Namespace"


### PR DESCRIPTION
### Fixes

* https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/547

### Description

* Reorganizes namespaces to a more logical organization
* LIBTYFI: Clean up some redundant code.

### Testing

- Run tests in `tests` directory, and confirm all function as expected
- Inspect API and confirm presence of expected changes.

### Performance

* No performance impact

### Docs

* API documentation updated

### Breaking Changes

- `/auth/permissions` now changed to `/permissions`
- `/auth/oauth` now changed to `/oauth/github`
- `/auth/login-with-github` now changed to `/oauth/login-with-github`
- `/auth/link-to-github` to `/oauth/link-to-github`
- `/login` to `/auth/login`
- `/refresh-session` to `/auth/refresh-session`
- `/request-reset-password` to `/auth/request-reset-password`
- `/reset-password` to `/auth/reset-password`
- `/reset-token-validation` to `/auth/reset-token-validation`