### PR TITLE
Mc 560 data requests get filter multiple statuses

### DIFF
--- a/database_client/db_client_dataclasses.py
+++ b/database_client/db_client_dataclasses.py
@@ -64,11 +64,22 @@ class WhereMapping:
         :param relation:
         :return: BinaryExpression. Example: Agency.municipality == "Pittsburgh"
         """
+        if isinstance(self.value, list):
+            return self.build_where_clause_in_list(relation)
         relation_reference = SQL_ALCHEMY_TABLE_REFERENCE[relation]
         if self.eq is True:
             return getattr(relation_reference, self.column) == self.value
         elif self.eq is False:
             return getattr(relation_reference, self.column) != self.value
+
+    def build_where_clause_in_list(self, relation: str) -> BinaryExpression:
+        """Creates a SQLAlchemy BinaryExpression for queries.
+
+        :param relation:
+        :return: BinaryExpression. Example: Agency.municipality == "Pittsburgh"
+        """
+        relation_reference = SQL_ALCHEMY_TABLE_REFERENCE[relation]
+        return getattr(relation_reference, self.column).in_(self.value)
 
     @staticmethod
     def from_dict(d: dict) -> list["WhereMapping"]:

--- a/middleware/primary_resource_logic/data_requests.py
+++ b/middleware/primary_resource_logic/data_requests.py
@@ -190,7 +190,7 @@ def get_data_requests_wrapper(
     }
     if dto.request_statuses is not None:
         db_client_additional_args["where_mappings"] = {
-            "request_statuses": [rs.value for rs in dto.request_statuses]
+            "request_status": [rs.value for rs in dto.request_statuses]
         }
     return get_many(
         middleware_parameters=MiddlewareParameters(

--- a/middleware/primary_resource_logic/data_requests.py
+++ b/middleware/primary_resource_logic/data_requests.py
@@ -188,9 +188,9 @@ def get_data_requests_wrapper(
             sort_by=dto.sort_by, sort_order=dto.sort_order
         ),
     }
-    if dto.request_status is not None:
+    if dto.request_statuses is not None:
         db_client_additional_args["where_mappings"] = {
-            "request_status": dto.request_status.value
+            "request_statuses": [rs.value for rs in dto.request_statuses]
         }
     return get_many(
         middleware_parameters=MiddlewareParameters(

--- a/middleware/schema_and_dto_logic/primary_resource_dtos/data_requests_dtos.py
+++ b/middleware/schema_and_dto_logic/primary_resource_dtos/data_requests_dtos.py
@@ -30,7 +30,7 @@ class DataRequestLocationInfoPostDTO(BaseModel):
 
 
 class GetManyDataRequestsRequestsDTO(GetManyBaseDTO):
-    request_status: Optional[RequestStatus] = None
+    request_statuses: Optional[list[RequestStatus]] = None
 
 
 class DataRequestsPutDTO(BaseModel):

--- a/middleware/schema_and_dto_logic/primary_resource_schemas/data_requests_advanced_schemas.py
+++ b/middleware/schema_and_dto_logic/primary_resource_schemas/data_requests_advanced_schemas.py
@@ -1,4 +1,4 @@
-from marshmallow import fields, Schema, post_load
+from marshmallow import fields, Schema, post_load, pre_load
 
 from database_client.enums import RequestStatus
 from middleware.schema_and_dto_logic.primary_resource_schemas.data_requests_base_schema import (
@@ -139,14 +139,23 @@ class DataRequestsPostSchema(Schema):
 
 class GetManyDataRequestsRequestsSchema(GetManyRequestsBaseSchema):
     request_statuses = fields.List(
-            fields.Enum(
-                enum=RequestStatus,
-                by_value=fields.Str,
-                allow_none=True,
-                metadata=get_query_metadata("The status of the requests to return."),
-            ),
+        fields.Enum(
+            enum=RequestStatus,
+            by_value=fields.Str,
+            allow_none=True,
+            metadata=get_query_metadata("The status of the requests to return."),
+        ),
         metadata=get_query_metadata("The status of the requests to return."),
     )
+
+    @pre_load
+    def listify_request_statuses(self, in_data, **kwargs):
+        request_statuses = in_data.get("request_statuses", None)
+        if request_statuses is None:
+            return in_data
+        in_data["request_statuses"] = request_statuses.split(",")
+
+        return in_data
 
 
 GetManyDataRequestsResponseSchema = create_get_many_schema(

--- a/middleware/schema_and_dto_logic/primary_resource_schemas/data_requests_advanced_schemas.py
+++ b/middleware/schema_and_dto_logic/primary_resource_schemas/data_requests_advanced_schemas.py
@@ -138,10 +138,13 @@ class DataRequestsPostSchema(Schema):
 
 
 class GetManyDataRequestsRequestsSchema(GetManyRequestsBaseSchema):
-    request_status = fields.Enum(
-        enum=RequestStatus,
-        by_value=fields.Str,
-        allow_none=True,
+    request_statuses = fields.List(
+            fields.Enum(
+                enum=RequestStatus,
+                by_value=fields.Str,
+                allow_none=True,
+                metadata=get_query_metadata("The status of the requests to return."),
+            ),
         metadata=get_query_metadata("The status of the requests to return."),
     )
 

--- a/middleware/util.py
+++ b/middleware/util.py
@@ -142,3 +142,19 @@ def get_temp_directory() -> str:
     # Go to root directory
 
     return os.path.join(os.getcwd(), "temp")
+
+
+def stringify_list_of_ints(l: list[int]):
+    for i in range(len(l)):
+        l[i] = str(l[i])
+    return l
+
+
+def stringify_lists(d: dict):
+    for k, v in d.items():
+        if isinstance(v, dict):
+            stringify_lists(v)
+        if isinstance(v, list):
+            v = stringify_list_of_ints(v)
+            d[k] = ",".join(v)
+    return d

--- a/tests/helper_scripts/helper_classes/RequestValidator.py
+++ b/tests/helper_scripts/helper_classes/RequestValidator.py
@@ -357,6 +357,7 @@ class RequestValidator:
         request_status: Optional[RequestStatus] = None,
         sort_by: Optional[str] = None,
         sort_order: Optional[SortOrder] = None,
+        request_statuses: Optional[list[RequestStatus]] = None,
     ):
         query_params = {}
         update_if_not_none(
@@ -364,8 +365,8 @@ class RequestValidator:
             secondary_dict={
                 "sort_by": sort_by,
                 "sort_order": sort_order.value if sort_order is not None else None,
-                "request_status": (
-                    request_status.value if request_status is not None else None
+                "request_statuses": (
+                    [rs.value for rs in request_statuses] if request_statuses is not None else None
                 ),
             },
         )

--- a/tests/helper_scripts/helper_classes/RequestValidator.py
+++ b/tests/helper_scripts/helper_classes/RequestValidator.py
@@ -354,7 +354,6 @@ class RequestValidator:
     def get_data_requests(
         self,
         headers: dict,
-        request_status: Optional[RequestStatus] = None,
         sort_by: Optional[str] = None,
         sort_order: Optional[SortOrder] = None,
         request_statuses: Optional[list[RequestStatus]] = None,
@@ -366,7 +365,9 @@ class RequestValidator:
                 "sort_by": sort_by,
                 "sort_order": sort_order.value if sort_order is not None else None,
                 "request_statuses": (
-                    [rs.value for rs in request_statuses] if request_statuses is not None else None
+                    [rs.value for rs in request_statuses]
+                    if request_statuses is not None
+                    else None
                 ),
             },
         )

--- a/tests/helper_scripts/helper_functions_simple.py
+++ b/tests/helper_scripts/helper_functions_simple.py
@@ -1,6 +1,8 @@
 from datetime import datetime, timezone, timedelta
 from urllib.parse import urlparse, parse_qs, urlencode, urlunparse
 
+from middleware.util import stringify_lists
+
 """
 `Simple` in this case refers to helper functions 
 which rely on no external dependencies
@@ -21,6 +23,8 @@ def add_query_params(url, params: dict):
     :param params:
     :return:
     """
+
+    stringify_lists(d=params)
 
     # Parse the original URL into components
     url_parts = list(urlparse(url))

--- a/tests/integration/test_bulk.py
+++ b/tests/integration/test_bulk.py
@@ -21,6 +21,7 @@ from middleware.schema_and_dto_logic.primary_resource_schemas.bulk_schemas impor
     AgenciesPutBatchRequestSchema,
     DataSourcesPutBatchRequestSchema,
 )
+from middleware.util import stringify_lists
 from tests.helper_scripts.common_test_data import get_test_name
 from tests.helper_scripts.common_asserts import assert_contains_key_value_pairs
 from tests.helper_scripts.helper_classes.RequestValidator import RequestValidator
@@ -32,22 +33,6 @@ from tests.helper_scripts.helper_classes.TestCSVCreator import TestCSVCreator
 from tests.helper_scripts.helper_classes.TestDataCreatorFlask import (
     TestDataCreatorFlask,
 )
-
-
-def stringify_list_of_ints(l: list[int]):
-    for i in range(len(l)):
-        l[i] = str(l[i])
-    return l
-
-
-def stringify_lists(d: dict):
-    for k, v in d.items():
-        if isinstance(v, dict):
-            stringify_lists(v)
-        if isinstance(v, list):
-            v = stringify_list_of_ints(v)
-            d[k] = ",".join(v)
-    return d
 
 
 @dataclass

--- a/tests/integration/test_data_requests.py
+++ b/tests/integration/test_data_requests.py
@@ -99,15 +99,13 @@ def test_data_requests_get(
         headers=tus_creator.jwt_authorization_header,
     )[DATA_KEY]
 
-
-
     # Assert admin columns are greater than user columns
     assert len(admin_data[0]) > len(data[0])
 
     # Run get again, this time filtering the request status to be active
     data = tdc.request_validator.get_data_requests(
         headers=tus_creator.jwt_authorization_header,
-        request_status=RequestStatus.ACTIVE,
+        request_statuses=[RequestStatus.ACTIVE],
     )[DATA_KEY]
 
     # The more recent data request should be returned, but the old one should be filtered out
@@ -121,7 +119,7 @@ def test_data_requests_get(
     def get_sorted_data_requests(sort_order: SortOrder):
         return tdc.request_validator.get_data_requests(
             headers=tus_creator.jwt_authorization_header,
-            request_status=RequestStatus.INTAKE,
+            request_statuses=[RequestStatus.INTAKE],
             sort_by="id",
             sort_order=sort_order,
         )

--- a/tests/integration/test_data_requests.py
+++ b/tests/integration/test_data_requests.py
@@ -73,6 +73,23 @@ def test_data_requests_get(
 
     assert len(data) == 2
 
+    # Add another data request, set its approval status to `Archived`
+    # THen perform a search for both Active and Archived
+    dr_info_3 = tdc.data_request(tus_creator)
+
+    tdc.request_validator.update_data_request(
+        data_request_id=dr_info_3.id,
+        headers=tdc.get_admin_tus().jwt_authorization_header,
+        entry_data={"request_status": "Archived"},
+    )
+
+    data = tdc.request_validator.get_data_requests(
+        headers=tus_creator.jwt_authorization_header,
+        request_statuses=[RequestStatus.ACTIVE, RequestStatus.ARCHIVED],
+    )[DATA_KEY]
+
+    assert len(data) == 2
+
     # Give user admin permission
     tdc.db_client.add_user_permission(
         user_id=tus_creator.user_info.user_id, permission=PermissionsEnum.DB_WRITE
@@ -81,6 +98,8 @@ def test_data_requests_get(
     admin_data = tdc.request_validator.get_data_requests(
         headers=tus_creator.jwt_authorization_header,
     )[DATA_KEY]
+
+
 
     # Assert admin columns are greater than user columns
     assert len(admin_data[0]) > len(data[0])


### PR DESCRIPTION
### Fixes

* https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/560

### Description

* Update `request_status` query parameter in `/data-requests` `GET` to `requests_statuses`, which can accept and filter on multiple request statuses at a time.
* Updated tests accordingly

### Testing

- Run tests in `tests` directory, and confirm all function as expected
- Inspect API and confirm presence of expected changes.

### Performance

* Impact marginal

### Docs

* API documentation updated.

### Breaking Changes

* `request_status` query parameter in `/data-requests` `GET` no longer functions: `request_statuses` must be used instead.