### PR TITLE
Mc 561 standardize locations

### DIFF
--- a/database_client/database_client.py
+++ b/database_client/database_client.py
@@ -1213,12 +1213,7 @@ class DatabaseClient:
         linked_relation=Relations.LOCATIONS_EXPANDED,
         linked_relation_linking_column="id",
         columns_to_retrieve=["state_name", "county_name", "locality_name", "id"],
-        alias_mappings={
-            "state_name": "state",
-            "county_name": "county",
-            "locality_name": "locality",
-            "id": "location_id",
-        },
+        build_metadata=True,
     )
 
     DataRequestIssueInfo = namedtuple(

--- a/database_client/dynamic_query_constructor.py
+++ b/database_client/dynamic_query_constructor.py
@@ -126,9 +126,9 @@ class DynamicQueryConstructor:
                 1 AS sort_order,
                 display_name,
                 type,
-                state_name as state,
-                county_name as county,
-                locality_name as locality,
+                state_name,
+                county_name,
+                locality_name,
                 location_id
             FROM typeahead_locations
             WHERE display_name ILIKE {search_term_prefix}
@@ -137,23 +137,23 @@ class DynamicQueryConstructor:
                 2 AS sort_order,
                 display_name,
                 type,
-                state_name as state,
-                county_name as county,
-                locality_name as locality,
+                state_name,
+                county_name,
+                locality_name,
                 location_id
             FROM typeahead_locations
             WHERE display_name ILIKE {search_term_anywhere}
             AND display_name NOT ILIKE {search_term_prefix}
         )
-        SELECT display_name, type, state, county, locality, location_id
+        SELECT display_name, type, state_name, county_name, locality_name, location_id
         FROM (
             SELECT DISTINCT 
                 sort_order,
                 display_name,
                 type,
-                state,
-                county,
-                locality,
+                state_name,
+                county_name,
+                locality_name,
                 location_id
             FROM combined
             ORDER BY sort_order, display_name
@@ -198,9 +198,9 @@ class DynamicQueryConstructor:
             id,
             name as display_name,
             jurisdiction_type,
-            state_iso as state,
-            municipality as locality,
-            county_name as county
+            state_iso,
+            municipality as locality_name,
+            county_name
         FROM (
             SELECT DISTINCT
                 sort_order,

--- a/database_client/subquery_logic.py
+++ b/database_client/subquery_logic.py
@@ -92,6 +92,8 @@ class SubqueryParameterManager:
             columns=[
                 "type",
                 "state_name",
+                "state_iso",
+                "county_fips",
                 "county_name",
                 "locality_name",
                 "display_name",

--- a/middleware/common_response_formatting.py
+++ b/middleware/common_response_formatting.py
@@ -13,13 +13,6 @@ from middleware.schema_and_dto_logic.common_response_schemas import (
 
 
 def format_list_response(data: dict, message: str = "") -> dict:
-    """
-    Format a list of dictionaries into a dictionary with the count and data keys.
-    Args:
-        data (list): A list of dictionaries to format.
-    Returns:
-        dict: A dictionary with the count and data keys.
-    """
     data.update({"message": message})
     return data
 

--- a/middleware/primary_resource_logic/data_requests.py
+++ b/middleware/primary_resource_logic/data_requests.py
@@ -78,9 +78,9 @@ def get_location_id_for_data_requests(
     # Rename keys to match where mappings
     revised_location_info = {
         "type": location_info.type,
-        "state_name": location_info.state,
-        "county_name": location_info.county,
-        "locality_name": location_info.locality,
+        "state_name": location_info.state_name,
+        "county_name": location_info.county_name,
+        "locality_name": location_info.locality_name,
     }
 
     location_id = db_client.get_location_id(
@@ -346,25 +346,7 @@ def get_data_request_by_id_wrapper(
             access_info=access_info,
             db_client_method=DatabaseClient.get_data_requests,
             entry_name="Data request",
-            subquery_parameters=[
-                SubqueryParameterManager.data_sources(),
-                SubqueryParameters(
-                    relation_name=Relations.LOCATIONS_EXPANDED.value,
-                    linking_column="locations",
-                    columns=[
-                        "type",
-                        "state_name",
-                        "county_name",
-                        "locality_name",
-                        "display_name",
-                    ],
-                    alias_mappings={
-                        "state_name": "state",
-                        "county_name": "county",
-                        "locality_name": "locality",
-                    },
-                ),
-            ],
+            subquery_parameters=get_data_requests_subquery_params(),
         ),
         relation_role_parameters=RelationRoleParameters(
             relation_role_function_with_params=DeferredFunction(

--- a/middleware/primary_resource_logic/locations_logic.py
+++ b/middleware/primary_resource_logic/locations_logic.py
@@ -12,6 +12,9 @@ from middleware.common_response_formatting import (
 )
 from middleware.enums import Relations
 from middleware.flask_response_manager import FlaskResponseManager
+from middleware.primary_resource_logic.data_requests import (
+    get_data_requests_subquery_params,
+)
 
 from middleware.schema_and_dto_logic.common_schemas_and_dtos import GetByIDBaseDTO
 
@@ -41,6 +44,8 @@ def get_locations_related_data_requests_wrapper(
             role=get_relation_role(access_info=access_info),
             column_permission=ColumnPermissionEnum.READ,
         ),
+        build_metadata=True,
+        subquery_parameters=get_data_requests_subquery_params(),
     )
     if results is None:
         return message_response(

--- a/middleware/primary_resource_logic/match_logic.py
+++ b/middleware/primary_resource_logic/match_logic.py
@@ -63,6 +63,7 @@ def try_getting_partial_match_agencies(dto: AgencyMatchDTO, agencies: list[dict]
 
     return partial_matches
 
+
 def format_response(amr: AgencyMatchResponse) -> Response:
     data = {
         "status": amr.status.value,
@@ -72,6 +73,7 @@ def format_response(amr: AgencyMatchResponse) -> Response:
     return FlaskResponseManager.make_response(
         data=data,
     )
+
 
 def match_agency_wrapper(db_client: DatabaseClient, dto: AgencyMatchOuterDTO):
     result = try_matching_agency(db_client=db_client, dto=dto)
@@ -128,7 +130,7 @@ def _get_agencies(db_client, location_id):
     )
 
 
-def _get_location_id(db_client, dto):
+def _get_location_id(db_client, dto: AgencyMatchDTO):
     return db_client.get_location_id(
         where_mappings=WhereMapping.from_dict(
             {

--- a/middleware/schema_and_dto_logic/primary_resource_dtos/data_requests_dtos.py
+++ b/middleware/schema_and_dto_logic/primary_resource_dtos/data_requests_dtos.py
@@ -13,19 +13,19 @@ from middleware.schema_and_dto_logic.common_schemas_and_dtos import (
 
 class DataRequestLocationInfoPostDTO(BaseModel):
     type: LocationType
-    state: str
-    county: Optional[str] = None
-    locality: Optional[str] = None
+    state_name: str
+    county_name: Optional[str] = None
+    locality_name: Optional[str] = None
 
     def get_where_mappings(self) -> list[WhereMapping]:
         d = {
             "type": self.type,
-            "state": self.state,
+            "state": self.state_name,
         }
-        if self.county is not None:
-            d["county"] = self.county
-        if self.locality is not None:
-            d["locality"] = self.locality
+        if self.county_name is not None:
+            d["county"] = self.county_name
+        if self.locality_name is not None:
+            d["locality"] = self.locality_name
         return WhereMapping.from_dict(d)
 
 

--- a/middleware/schema_and_dto_logic/primary_resource_schemas/data_requests_advanced_schemas.py
+++ b/middleware/schema_and_dto_logic/primary_resource_schemas/data_requests_advanced_schemas.py
@@ -120,7 +120,7 @@ class DataRequestsPostSchema(Schema):
     location_infos = fields.List(
         fields.Nested(
             nested=TypeaheadLocationsResponseSchema(
-                exclude=["display_name", "location_id"]
+                only=["type", "state_name", "county_name", "locality_name"]
             ),
             metadata=get_json_metadata(
                 "The locations associated with the data request",

--- a/middleware/schema_and_dto_logic/primary_resource_schemas/locations_schemas.py
+++ b/middleware/schema_and_dto_logic/primary_resource_schemas/locations_schemas.py
@@ -63,9 +63,11 @@ COUNTY_NAME_FIELD = fields.Str(
 
 class LocationInfoResponseSchema(Schema):
     type = LOCATION_TYPE_FIELD
-    state = STATE_NAME_FIELD
-    county = COUNTY_NAME_FIELD
-    locality = LOCALITY_NAME_FIELD
+    state_name = STATE_NAME_FIELD
+    state_iso = STATE_ISO_FIELD
+    county_name = COUNTY_FIPS_FIELD
+    county_fips = COUNTY_NAME_FIELD
+    locality_name = LOCALITY_NAME_FIELD
     display_name = fields.Str(
         required=True,
         metadata=get_json_metadata(description="The display name for the location"),

--- a/middleware/schema_and_dto_logic/primary_resource_schemas/search_schemas.py
+++ b/middleware/schema_and_dto_logic/primary_resource_schemas/search_schemas.py
@@ -49,7 +49,6 @@ class SearchRequestSchema(Schema):
     )
 
 
-
 class SearchResultsInnerSchema(Schema):
     id = fields.Int(
         required=True,
@@ -158,25 +157,25 @@ class SearchResponseSchema(Schema):
 
 
 class FollowSearchResponseSchema(Schema):
-    state = fields.Str(
+    state_name = fields.Str(
         required=True,
         metadata=get_json_metadata("The state of the search."),
     )
-    county = fields.Str(
+    county_name = fields.Str(
         required=False,
         allow_none=True,
         metadata=get_json_metadata(
             "The county of the search. If empty, all counties for the given state will be searched."
         ),
     )
-    locality = fields.Str(
+    locality_name = fields.Str(
         required=False,
         allow_none=True,
         metadata=get_json_metadata(
             "The locality of the search. If empty, all localities for the given county will be searched."
         ),
     )
-    location_id = fields.Int(
+    id = fields.Int(
         required=True,
         metadata=get_json_metadata("The location ID of the search."),
     )

--- a/middleware/schema_and_dto_logic/primary_resource_schemas/typeahead_suggestion_schemas.py
+++ b/middleware/schema_and_dto_logic/primary_resource_schemas/typeahead_suggestion_schemas.py
@@ -16,7 +16,7 @@ JURISDICTION_TYPES = [
 
 
 class TypeaheadBaseResponseSchema(Schema):
-    state = fields.String(
+    state_name = fields.String(
         required=True,
         metadata={
             "source": SourceMappingEnum.JSON,
@@ -24,7 +24,15 @@ class TypeaheadBaseResponseSchema(Schema):
             "example": "Pennsylvania",
         },
     )
-    county = fields.String(
+    state_iso = fields.String(
+        required=True,
+        metadata={
+            "source": SourceMappingEnum.JSON,
+            "description": "The state ISO of the suggestion",
+            "example": "PA",
+        },
+    )
+    county_name = fields.String(
         required=True,
         metadata={
             "source": SourceMappingEnum.JSON,
@@ -33,7 +41,7 @@ class TypeaheadBaseResponseSchema(Schema):
         },
         allow_none=True,
     )
-    locality = fields.String(
+    locality_name = fields.String(
         required=True,
         metadata={
             "source": SourceMappingEnum.JSON,
@@ -104,7 +112,7 @@ class TypeaheadAgenciesOuterResponseSchema(Schema):
     # pass
     suggestions = fields.List(
         cls_or_instance=fields.Nested(
-            nested=TypeaheadAgenciesResponseSchema,
+            nested=TypeaheadAgenciesResponseSchema(exclude=["state_name"]),
             required=True,
             metadata={
                 "source": SourceMappingEnum.JSON,
@@ -122,7 +130,7 @@ class TypeaheadLocationsOuterResponseSchema(Schema):
 
     suggestions = fields.List(
         cls_or_instance=fields.Nested(
-            nested=TypeaheadLocationsResponseSchema,
+            nested=TypeaheadLocationsResponseSchema(exclude=["state_iso"]),
             required=True,
             metadata={
                 "source": SourceMappingEnum.JSON,

--- a/resources/endpoint_schema_config.py
+++ b/resources/endpoint_schema_config.py
@@ -545,8 +545,6 @@ class SchemaConfigs(Enum):
     LOCATIONS_RELATED_DATA_REQUESTS_GET = EndpointSchemaConfig(
         input_schema=GetByIDBaseSchema(),
         input_dto_class=GetByIDBaseDTO,
-        primary_output_schema=GetManyDataRequestsResponseSchema(
-            exclude=["data.data_sources", "data.locations"]
-        ),
+        primary_output_schema=GetManyDataRequestsResponseSchema(),
     )
     # endregion

--- a/tests/integration/test_data_requests.py
+++ b/tests/integration/test_data_requests.py
@@ -169,15 +169,15 @@ def test_data_requests_post(
 
     location_info_1 = {
         "type": "Locality",
-        "state": "California",
-        "county": "Orange",
-        "locality": "Laguna Hills",
+        "state_name": "California",
+        "county_name": "Orange",
+        "locality_name": "Laguna Hills",
     }
     location_info_2 = {
         "type": "Locality",
-        "state": "California",
-        "county": "Orange",
-        "locality": "Seal Beach",
+        "state_name": "California",
+        "county_name": "Orange",
+        "locality_name": "Seal Beach",
     }
 
     json_request = {
@@ -202,9 +202,9 @@ def test_data_requests_post(
     locations = data["locations"]
     assert len(locations) == 2
     for location in locations:
-        if location["locality"] == location_info_1["locality"]:
+        if location["locality_name"] == location_info_1["locality_name"]:
             continue
-        if location["locality"] == location_info_2["locality"]:
+        if location["locality_name"] == location_info_2["locality_name"]:
             continue
         assert False
 

--- a/tests/integration/test_locations.py
+++ b/tests/integration/test_locations.py
@@ -67,4 +67,6 @@ def test_locations_related_data_requests(locations_test_setup: LocationsTestSetu
     data = tdc.request_validator.get_location_related_data_requests(
         location_id=lts.location_info["id"],
         headers=tus.jwt_authorization_header,
-    )
+    )["data"]
+    assert data[0]["locations"] == data[1]["locations"]
+    assert data[0]["locations"][0]["id"] == lts.location_info["id"]

--- a/tests/integration/test_search.py
+++ b/tests/integration/test_search.py
@@ -33,11 +33,13 @@ TEST_STATE = "Pennsylvania"
 TEST_COUNTY = "Allegheny"
 TEST_LOCALITY = "Pittsburgh"
 
+
 @dataclass
 class SearchTestSetup:
     tdc: TestDataCreatorFlask
     location_id: int
     tus: TestUserSetup
+
 
 @pytest.fixture
 def search_test_setup(test_data_creator_flask: TestDataCreatorFlask):
@@ -49,9 +51,11 @@ def search_test_setup(test_data_creator_flask: TestDataCreatorFlask):
                 "state_name": TEST_STATE,
                 "county_name": TEST_COUNTY,
                 "locality_name": TEST_LOCALITY,
-        }),
+            }
+        ),
         tus=tdc.standard_user(),
     )
+
 
 def test_search_get(search_test_setup: SearchTestSetup):
     sts = search_test_setup
@@ -252,12 +256,14 @@ def test_search_follow(search_test_setup: SearchTestSetup):
         tus=tus_1,
         expected_json_content={
             "metadata": {"count": 1},
-            "data": [{
-                "state": TEST_STATE,
-                "county": TEST_COUNTY,
-                "locality": TEST_LOCALITY,
-                "location_id": sts.location_id
-            }],
+            "data": [
+                {
+                    "state_name": TEST_STATE,
+                    "county_name": TEST_COUNTY,
+                    "locality_name": TEST_LOCALITY,
+                    "id": sts.location_id,
+                }
+            ],
             "message": "Followed searches found.",
         },
     )

--- a/tests/integration/test_typeahead_suggestions.py
+++ b/tests/integration/test_typeahead_suggestions.py
@@ -21,23 +21,23 @@ def test_typeahead_locations(flask_client_with_db):
     expected_suggestions = [
         {
             "display_name": "Xylodammerung",
-            "locality": "Xylodammerung",
-            "county": "Arxylodon",
-            "state": "Xylonsylvania",
+            "locality_name": "Xylodammerung",
+            "county_name": "Arxylodon",
+            "state_name": "Xylonsylvania",
             "type": "Locality",
         },
         {
             "display_name": "Xylonsylvania",
-            "locality": None,
-            "county": None,
-            "state": "Xylonsylvania",
+            "locality_name": None,
+            "county_name": None,
+            "state_name": "Xylonsylvania",
             "type": "State",
         },
         {
             "display_name": "Arxylodon",
-            "locality": None,
-            "county": "Arxylodon",
-            "state": "Xylonsylvania",
+            "locality_name": None,
+            "county_name": "Arxylodon",
+            "state_name": "Xylonsylvania",
             "type": "County",
         },
     ]

--- a/tests/integration/test_user_profile.py
+++ b/tests/integration/test_user_profile.py
@@ -45,13 +45,25 @@ def test_user_profile_get_by_id(test_data_creator_flask: TestDataCreatorFlask):
     # Create a recent search
     tdc.request_validator.search(
         headers=tus.api_authorization_header,
-        location_id=tdc.db_client.get_location_id(where_mappings={"state_name": "Pennsylvania", "county_name": None, "locality_name": None}),
+        location_id=tdc.db_client.get_location_id(
+            where_mappings={
+                "state_name": "Pennsylvania",
+                "county_name": None,
+                "locality_name": None,
+            }
+        ),
     )
 
     # Have the user follow a search
     tdc.request_validator.follow_search(
         headers=tus.jwt_authorization_header,
-        location_id=tdc.db_client.get_location_id(where_mappings={"state_name": "California", "county_name": None, "locality_name": None}),
+        location_id=tdc.db_client.get_location_id(
+            where_mappings={
+                "state_name": "California",
+                "county_name": None,
+                "locality_name": None,
+            }
+        ),
     )
 
     # Have the user create a data request
@@ -77,7 +89,7 @@ def test_user_profile_get_by_id(test_data_creator_flask: TestDataCreatorFlask):
     assert data["email"] == tus.user_info.email
     assert data["external_accounts"]["github"] == str(github_user_id)
     assert data["recent_searches"]["data"][0]["state_iso"] == "PA"
-    assert data["followed_searches"]["data"][0]["state"] == "California"
+    assert data["followed_searches"]["data"][0]["state_name"] == "California"
     assert data["data_requests"]["data"][0]["id"] == int(data_request_id)
     assert data["permissions"] == [PermissionsEnum.READ_ALL_USER_INFO.value]
 

--- a/tests/test_database_client.py
+++ b/tests/test_database_client.py
@@ -577,21 +577,21 @@ def test_get_typeahead_locations(live_database_client: DatabaseClient):
 
     assert results[0]["display_name"] == "Xylodammerung"
     assert results[0]["type"] == "Locality"
-    assert results[0]["state"] == "Xylonsylvania"
-    assert results[0]["county"] == "Arxylodon"
-    assert results[0]["locality"] == "Xylodammerung"
+    assert results[0]["state_name"] == "Xylonsylvania"
+    assert results[0]["county_name"] == "Arxylodon"
+    assert results[0]["locality_name"] == "Xylodammerung"
 
     assert results[1]["display_name"] == "Xylonsylvania"
     assert results[1]["type"] == "State"
-    assert results[1]["state"] == "Xylonsylvania"
-    assert results[1]["county"] is None
-    assert results[1]["locality"] is None
+    assert results[1]["state_name"] == "Xylonsylvania"
+    assert results[1]["county_name"] is None
+    assert results[1]["locality_name"] is None
 
     assert results[2]["display_name"] == "Arxylodon"
     assert results[2]["type"] == "County"
-    assert results[2]["state"] == "Xylonsylvania"
-    assert results[2]["county"] == "Arxylodon"
-    assert results[2]["locality"] is None
+    assert results[2]["state_name"] == "Xylonsylvania"
+    assert results[2]["county_name"] == "Arxylodon"
+    assert results[2]["locality_name"] is None
 
 
 def test_get_typeahead_agencies(live_database_client):
@@ -603,9 +603,9 @@ def test_get_typeahead_agencies(live_database_client):
     assert len(results) > 0
     assert results[0]["display_name"] == "Xylodammerung Police Agency"
     assert results[0]["jurisdiction_type"] == "state"
-    assert results[0]["state"] == "XY"
-    assert results[0]["county"] == "Arxylodon"
-    assert results[0]["locality"] == "Xylodammerung"
+    assert results[0]["state_iso"] == "XY"
+    assert results[0]["county_name"] == "Arxylodon"
+    assert results[0]["locality_name"] == "Xylodammerung"
 
 
 def test_search_with_location_and_record_types_real_data(live_database_client):
@@ -626,7 +626,7 @@ def test_search_with_location_and_record_types_real_data(live_database_client):
     county_parameter = "Allegheny"
     locality_parameter = "Pittsburgh"
 
-    def search(state, record_categories = None, county = None, locality = None):
+    def search(state, record_categories=None, county=None, locality=None):
         location_id = live_database_client.get_location_id(
             where_mappings={
                 "state_name": state,
@@ -650,14 +650,8 @@ def test_search_with_location_and_record_types_real_data(live_database_client):
             locality=locality_parameter,
         )
     )
-    S = len(
-        search(state=state_parameter)
-    )
-    SR = len(
-        search(
-            state=state_parameter, record_categories=[record_type_parameter]
-        )
-    )
+    S = len(search(state=state_parameter))
+    SR = len(search(state=state_parameter, record_categories=[record_type_parameter]))
     SRC = len(
         search(
             state=state_parameter,
@@ -670,11 +664,7 @@ def test_search_with_location_and_record_types_real_data(live_database_client):
             state=state_parameter, county=county_parameter, locality=locality_parameter
         )
     )
-    SC = len(
-        search(
-            state=state_parameter, county=county_parameter
-        )
-    )
+    SC = len(search(state=state_parameter, county=county_parameter))
 
     assert SRLC > 0
     assert SRLC < SRC
@@ -687,7 +677,11 @@ def test_search_with_location_and_record_types_real_data_multiple_records(
     live_database_client,
 ):
     location_id = live_database_client.get_location_id(
-        where_mappings={"state_name": "Pennsylvania", "county_name": None, "locality_name": None}
+        where_mappings={
+            "state_name": "Pennsylvania",
+            "county_name": None,
+            "locality_name": None,
+        }
     )
     record_categories = []
     last_count = 0
@@ -702,7 +696,9 @@ def test_search_with_location_and_record_types_real_data_multiple_records(
         results = live_database_client.search_with_location_and_record_type(
             location_id=location_id, record_categories=record_categories
         )
-        assert len(results) > last_count, f"{record_category} failed (total record_categories: {len(record_categories)})"
+        assert (
+            len(results) > last_count
+        ), f"{record_category} failed (total record_categories: {len(record_categories)})"
         last_count = len(results)
 
     # Finally, check that all record_types is equivalent to no record types in terms of number of results
@@ -1061,6 +1057,7 @@ def test_get_linked_rows(
             "id",
             "name",
         ],
+        build_metadata=True,
     )
 
     assert results["metadata"]["count"] == len(results["data"]) > 0


### PR DESCRIPTION
### Fixes

* https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/565

### Description

* Standardizes location information across multiple endpoints, such that location information is listed the same way every time.
* This listing is as follows:
```
{
  "id": number
  "type": "string",
  "state_iso": "string",
  "county_fips": "string",
  "locality_name": "string",
  "state_name": "string",
  "county_name": "string"
}
```

### Testing

- Run tests in `tests` directory, and confirm all function as expected
- Inspect API and confirm presence of expected changes.

### Performance

* Impact marginal

### Docs

* Documentation updated

### Breaking Changes

* The following endpoints have been updated:
* `/search/follow` `GET`
* `/typeahead/agencies` `GET`
* `/typeahead/locations` `GET`
* `/data-requests` `GET`
* `/data-requests/{resource_id}/related-locations` `GET`
* `/locations/{resource_id}/data-requests` `GET`
* `/user/data-requests` `GET`