### PR TITLE
Convert references to location's `id` to `location_id`

### DIFF
--- a/database_client/database_client.py
+++ b/database_client/database_client.py
@@ -934,12 +934,14 @@ class DatabaseClient:
         columns: list[str],
         where_mappings: Optional[Union[list[WhereMapping], dict]] = [True],
         subquery_parameters: Optional[list[SubqueryParameters]] = [],
+        **kwargs,
     ) -> Any:
         results = self._select_from_relation(
             relation_name=relation_name,
             columns=columns,
             where_mappings=where_mappings,
             subquery_parameters=subquery_parameters,
+            **kwargs,
         )
         if len(results) == 0:
             return None
@@ -1151,9 +1153,6 @@ class DatabaseClient:
         build_metadata=False,
         subquery_parameters: Optional[list[SubqueryParameters]] = [],
     ):
-        LinkTable = SQL_ALCHEMY_TABLE_REFERENCE[link_table.value]
-        LinkedRelation = SQL_ALCHEMY_TABLE_REFERENCE[linked_relation.value]
-
         # Get ids via linked table
         link_results = self._select_from_relation(
             relation_name=link_table.value,
@@ -1214,6 +1213,7 @@ class DatabaseClient:
         linked_relation_linking_column="id",
         columns_to_retrieve=["state_name", "county_name", "locality_name", "id"],
         build_metadata=True,
+        alias_mappings={"id": "location_id"},
     )
 
     DataRequestIssueInfo = namedtuple(
@@ -1484,4 +1484,5 @@ class DatabaseClient:
                 "id",
             ],
             where_mappings={"id": location_id},
+            alias_mappings={"id": "location_id"},
         )

--- a/database_client/subquery_logic.py
+++ b/database_client/subquery_logic.py
@@ -46,10 +46,16 @@ class SubqueryParameterManager:
 
     @staticmethod
     def get_subquery_params(
-        relation: Relations, linking_column: str, columns: list[str] = None
+        relation: Relations,
+        linking_column: str,
+        columns: list[str] = None,
+        alias_mappings: Optional[dict[str, str]] = None,
     ) -> SubqueryParameters:
         return SubqueryParameters(
-            relation_name=relation.value, linking_column=linking_column, columns=columns
+            relation_name=relation.value,
+            linking_column=linking_column,
+            columns=columns,
+            alias_mappings=alias_mappings,
         )
 
     agencies = partialmethod(
@@ -98,4 +104,5 @@ class SubqueryParameterManager:
                 "locality_name",
                 "display_name",
             ],
+            alias_mappings={"id": "location_id"},
         )

--- a/middleware/dynamic_request_logic/get_related_resource_logic.py
+++ b/middleware/dynamic_request_logic/get_related_resource_logic.py
@@ -31,6 +31,7 @@ class GetRelatedResourcesParameters:
 def get_related_resource(
     get_related_resources_parameters: GetRelatedResourcesParameters,
     permitted_columns: Optional[list] = None,
+    alias_mappings: Optional[dict] = None,
 ) -> Response:
     # Technically, it'd make more sense as "grrp",
     # but "gerp" rolls off the tongue better
@@ -54,6 +55,7 @@ def get_related_resource(
             relation=gerp.related_relation,
             linking_column=gerp.linking_column,
             columns=permitted_columns,
+            alias_mappings=alias_mappings,
         )
     ]
     where_mappings = [

--- a/middleware/primary_resource_logic/data_requests.py
+++ b/middleware/primary_resource_logic/data_requests.py
@@ -396,6 +396,7 @@ def get_data_request_related_locations(
             "locality_name",
             "type",
         ],
+        alias_mappings={"id": "location_id"},
     )
 
 

--- a/middleware/schema_and_dto_logic/primary_resource_schemas/locations_schemas.py
+++ b/middleware/schema_and_dto_logic/primary_resource_schemas/locations_schemas.py
@@ -72,7 +72,7 @@ class LocationInfoResponseSchema(Schema):
         required=True,
         metadata=get_json_metadata(description="The display name for the location"),
     )
-    id = LOCATION_ID_FIELD
+    location_id = LOCATION_ID_FIELD
 
 
 class LocationInfoSchema(Schema):
@@ -80,7 +80,7 @@ class LocationInfoSchema(Schema):
     state_iso = STATE_ISO_FIELD
     county_fips = COUNTY_FIPS_FIELD
     locality_name = LOCALITY_NAME_FIELD
-    id = LOCATION_ID_FIELD
+    location_id = LOCATION_ID_FIELD
 
     @validates_schema
     def validate_location_fields(self, data, **kwargs):

--- a/middleware/schema_and_dto_logic/primary_resource_schemas/search_schemas.py
+++ b/middleware/schema_and_dto_logic/primary_resource_schemas/search_schemas.py
@@ -175,7 +175,7 @@ class FollowSearchResponseSchema(Schema):
             "The locality of the search. If empty, all localities for the given county will be searched."
         ),
     )
-    id = fields.Int(
+    location_id = fields.Int(
         required=True,
         metadata=get_json_metadata("The location ID of the search."),
     )

--- a/tests/integration/test_data_requests.py
+++ b/tests/integration/test_data_requests.py
@@ -642,7 +642,7 @@ def test_link_unlink_data_requests_with_locations(
     data = get_locations()
     assert data == [
         {
-            "id": location_id,
+            "location_id": location_id,
             "state_name": "Pennsylvania",
             "state_iso": "PA",
             "county_name": "Allegheny",

--- a/tests/integration/test_locations.py
+++ b/tests/integration/test_locations.py
@@ -28,7 +28,7 @@ def locations_test_setup(test_data_creator_flask: TestDataCreatorFlask):
         "county_name": "Allegheny",
         "county_fips": "42003",
         "locality_name": locality_name,
-        "id": location_id,
+        "location_id": location_id,
     }
     return LocationsTestSetup(tdc=tdc, location_info=loc_info)
 
@@ -39,7 +39,7 @@ def test_locations_get_by_id(locations_test_setup: LocationsTestSetup):
 
     # Get location, confirm information matches
     data = tdc.request_validator.get_location_by_id(
-        location_id=lts.location_info["id"],
+        location_id=lts.location_info["location_id"],
         headers=tdc.get_admin_tus().jwt_authorization_header,
         expected_json_content=lts.location_info,
     )
@@ -48,15 +48,16 @@ def test_locations_get_by_id(locations_test_setup: LocationsTestSetup):
 def test_locations_related_data_requests(locations_test_setup: LocationsTestSetup):
     lts = locations_test_setup
     tdc = lts.tdc
+    location_id = lts.location_info["location_id"]
 
     # Add two data requests to location
-    dr_1 = tdc.data_request(location_ids=[lts.location_info["id"]]).id
-    dr_2 = tdc.data_request(location_ids=[lts.location_info["id"]]).id
+    dr_1 = tdc.data_request(location_ids=[location_id]).id
+    dr_2 = tdc.data_request(location_ids=[location_id]).id
 
     # Get data requests
     tus = tdc.standard_user()
     data = tdc.request_validator.get_location_related_data_requests(
-        location_id=lts.location_info["id"],
+        location_id=location_id,
         headers=tus.api_authorization_header,
     )
 
@@ -65,8 +66,8 @@ def test_locations_related_data_requests(locations_test_setup: LocationsTestSetu
 
     # Confirm also works with jwt
     data = tdc.request_validator.get_location_related_data_requests(
-        location_id=lts.location_info["id"],
+        location_id=location_id,
         headers=tus.jwt_authorization_header,
     )["data"]
     assert data[0]["locations"] == data[1]["locations"]
-    assert data[0]["locations"][0]["id"] == lts.location_info["id"]
+    assert data[0]["locations"][0]["location_id"] == location_id

--- a/tests/integration/test_search.py
+++ b/tests/integration/test_search.py
@@ -262,7 +262,7 @@ def test_search_follow(search_test_setup: SearchTestSetup):
                     "state_name": TEST_STATE,
                     "county_name": TEST_COUNTY,
                     "locality_name": TEST_LOCALITY,
-                    "id": sts.location_id,
+                    "location_id": sts.location_id,
                 }
             ],
             "message": "Followed searches found.",


### PR DESCRIPTION
### Fixes

* https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/570

### Description

* Convert references to location's id to location_id

### Testing

* Run tests in `tests` directory and confirm functionality
* Look for references, such as this one in `/data-requests/{resource_id}/related-locations`, to be changed:

![image](https://github.com/user-attachments/assets/08fe4107-f835-4455-b45d-5991cd74baf6)


### Performance

* Impact marginal

### Docs

* Documentation updated

### Breaking Changes

* References to a location's `id` have been changed to the more explicit `location_id`