### PR TITLE
Remove `agencies.submitted_name`:

### DIFF
--- a/alembic/versions/8ba99f12446d_remove_agencies_name_and_make_submitted_.py
+++ b/alembic/versions/8ba99f12446d_remove_agencies_name_and_make_submitted_.py
@@ -1,0 +1,218 @@
+"""Remove agencies.name and make submitted_name new name column
+
+Revision ID: 8ba99f12446d
+Revises: 12cf56cbebb7
+Create Date: 2025-02-06 09:06:46.556363
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import String, Column
+
+# revision identifiers, used by Alembic.
+revision: str = "8ba99f12446d"
+down_revision: Union[str, None] = "12cf56cbebb7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+CREATE_MATERIALIZED_VIEW_SCRIPT = """
+    CREATE MATERIALIZED VIEW IF NOT EXISTS public.typeahead_agencies
+    TABLESPACE pg_default
+    AS
+     SELECT a.id,
+        a.name,
+        a.jurisdiction_type,
+        l.state_iso,
+        l.locality_name AS municipality,
+        l.county_name
+       FROM agencies a
+         LEFT JOIN locations_expanded l ON a.location_id = l.id
+    WITH DATA;
+"""
+DROP_VIEW_SCRIPT = "DROP VIEW public.agencies_expanded;"
+DROP_MATERIALIZED_VIEW_SCRIPT = "DROP MATERIALIZED VIEW public.typeahead_agencies;"
+
+
+def upgrade() -> None:
+    op.execute(DROP_VIEW_SCRIPT)
+    op.execute(DROP_MATERIALIZED_VIEW_SCRIPT)
+    op.drop_column(table_name="agencies", column_name="name")
+    op.execute(
+        """
+    DROP TRIGGER IF EXISTS trigger_set_agency_name ON public.agencies;
+    DROP FUNCTION IF EXISTS set_agency_name();
+    COMMIT;
+    """
+    )
+    op.alter_column(
+        table_name="agencies", column_name="submitted_name", new_column_name="name"
+    )
+    op.execute(
+        """
+    CREATE OR REPLACE VIEW public.agencies_expanded
+     AS
+     SELECT a.name,
+        a.name as submitted_name,
+        a.homepage_url,
+        a.jurisdiction_type,
+        l.state_iso,
+        l.state_name,
+        l.county_fips,
+        l.county_name,
+        a.lat,
+        a.lng,
+        a.defunct_year,
+        a.id,
+        a.agency_type,
+        a.multi_agency,
+        a.zip_code,
+        a.no_web_presence,
+        a.airtable_agency_last_modified,
+        a.approved,
+        a.rejection_reason,
+        a.last_approval_editor,
+        a.submitter_contact,
+        a.agency_created,
+        l.locality_name
+       FROM agencies a
+         LEFT JOIN locations_expanded l ON a.location_id = l.id;
+    COMMENT ON VIEW public.agencies_expanded
+        IS 'View containing information about agencies as well as limited information from other tables connected by foreign keys.';
+    """
+    )
+    op.execute(CREATE_MATERIALIZED_VIEW_SCRIPT)
+
+    op.execute(
+        """
+    WITH agency_rc_id AS(
+    
+        SELECT rc.id
+        FROM relation_column rc
+        WHERE rc.relation = 'agencies'
+        AND rc.associated_column = 'name'
+    
+    )
+    
+    UPDATE COLUMN_PERMISSION CP
+    SET ACCESS_PERMISSION = 'WRITE'
+    WHERE CP.RC_ID IN (SELECT ID FROM agency_rc_id) AND CP.RELATION_ROLE = 'ADMIN';
+    """
+    )
+
+
+def downgrade() -> None:
+    op.execute(DROP_VIEW_SCRIPT)
+    op.execute(DROP_MATERIALIZED_VIEW_SCRIPT)
+    op.alter_column(
+        table_name="agencies", column_name="name", new_column_name="submitted_name"
+    )
+    op.add_column(table_name="agencies", column=Column(name="name", type_=String()))
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION public.set_agency_name()
+        RETURNS trigger
+        LANGUAGE 'plpgsql'
+        COST 100
+        VOLATILE NOT LEAKPROOF
+    AS $BODY$
+    BEGIN
+        IF NEW.submitted_name IS NOT NULL THEN
+            IF NEW.state_iso IS NOT NULL THEN
+                NEW.name := NEW.submitted_name || ' - ' || NEW.state_iso;
+            ELSE
+                NEW.name := NEW.submitted_name;
+            END IF;
+        END IF;
+    
+        RETURN NEW;
+    END;
+    $BODY$;
+    
+    COMMENT ON FUNCTION public.set_agency_name()
+    IS 'Updates `name` based on contents of `submitted_name` and `state_iso`';
+    """
+    )
+
+    op.execute(
+        """
+    CREATE OR REPLACE TRIGGER trigger_set_agency_name
+    BEFORE INSERT OR UPDATE 
+    ON public.agencies
+    FOR EACH ROW
+    EXECUTE FUNCTION public.set_agency_name();
+
+    COMMENT ON TRIGGER trigger_set_agency_name ON public.agencies
+        IS 'Calls `set_agency_name()` on inserts or updates to an Agency Row';
+    """
+    )
+
+    op.execute(
+        """
+    CREATE OR REPLACE VIEW public.agencies_expanded
+     AS
+     SELECT a.name,
+        a.submitted_name,
+        a.homepage_url,
+        a.jurisdiction_type,
+        l.state_iso,
+        l.state_name,
+        l.county_fips,
+        l.county_name,
+        a.lat,
+        a.lng,
+        a.defunct_year,
+        a.id,
+        a.agency_type,
+        a.multi_agency,
+        a.zip_code,
+        a.no_web_presence,
+        a.airtable_agency_last_modified,
+        a.approved,
+        a.rejection_reason,
+        a.last_approval_editor,
+        a.submitter_contact,
+        a.agency_created,
+        l.locality_name
+       FROM agencies a
+         LEFT JOIN locations_expanded l ON a.location_id = l.id;
+         
+     COMMENT ON VIEW public.agencies_expanded
+        IS 'View containing information about agencies as well as limited information from other tables connected by foreign keys.';
+     """
+    )
+    op.execute(
+        """
+    CREATE MATERIALIZED VIEW IF NOT EXISTS public.typeahead_agencies
+    TABLESPACE pg_default
+    AS
+     SELECT a.id,
+        a.name,
+        a.jurisdiction_type,
+        l.state_iso,
+        l.locality_name AS municipality,
+        l.county_name
+       FROM agencies a
+         LEFT JOIN locations_expanded l ON a.location_id = l.id
+    WITH DATA;
+    """
+    )
+
+    op.execute(
+        """
+    WITH agency_rc_id AS(
+
+    SELECT rc.id
+    FROM relation_column rc
+    WHERE rc.relation = 'agencies'
+    AND rc.associated_column = 'name'
+
+    )
+
+    UPDATE COLUMN_PERMISSION CP
+    SET ACCESS_PERMISSION = 'READ'
+    WHERE CP.RC_ID IN (SELECT ID FROM agency_rc_id) AND CP.RELATION_ROLE = 'ADMIN';
+    """
+    )

--- a/conftest.py
+++ b/conftest.py
@@ -20,6 +20,12 @@ from tests.helper_scripts.helper_classes.TestDataCreatorDBClient import (
 dotenv.load_dotenv()
 
 
+def get_alembic_conn_string() -> str:
+    conn_string = get_env_variable("DO_DATABASE_URL")
+    conn_string = conn_string.replace("postgresql", "postgresql+psycopg")
+    return conn_string
+
+
 def downgrade_to_base(alembic_cfg: Config, engine):
     try:
         command.downgrade(alembic_cfg, "base")
@@ -35,8 +41,7 @@ def downgrade_to_base(alembic_cfg: Config, engine):
 
 @pytest.fixture(scope="session", autouse=True)
 def setup_database():
-    conn_string = get_env_variable("DO_DATABASE_URL")
-    conn_string = conn_string.replace("postgresql", "postgresql+psycopg")
+    conn_string = get_alembic_conn_string()
     engine = create_engine(conn_string)
     # Base.metadata.drop_all(engine)
     alembic_cfg = Config("alembic.ini")
@@ -47,6 +52,10 @@ def setup_database():
     except Exception as e:
         # Downgrade to base and try again
         downgrade_to_base(alembic_cfg, engine)
+        connection = alembic_cfg.attributes["connection"]
+        connection.exec_driver_sql("DROP SCHEMA public CASCADE;")
+        connection.exec_driver_sql("CREATE SCHEMA public;")
+        connection.commit()
         command.upgrade(alembic_cfg, "head")
     yield
     downgrade_to_base(alembic_cfg, engine)

--- a/database_client/models.py
+++ b/database_client/models.py
@@ -14,6 +14,7 @@ from sqlalchemy import (
     Enum,
     Integer,
     UniqueConstraint,
+    inspect,
 )
 from sqlalchemy.dialects.postgresql import (
     ARRAY,
@@ -22,12 +23,14 @@ from sqlalchemy.dialects.postgresql import (
     TIMESTAMP,
     ENUM as pgEnum,
 )
-from sqlalchemy.ext.hybrid import hybrid_method
+from sqlalchemy.ext.hybrid import hybrid_method, hybrid_property
 from sqlalchemy.orm import (
     DeclarativeBase,
     Mapped,
     mapped_column,
     relationship,
+    column_property,
+    MappedColumn,
 )
 from sqlalchemy.sql.expression import false, func
 
@@ -222,14 +225,20 @@ class Agency(Base, CountMetadata):
 
     id: Mapped[int] = mapped_column(primary_key=True)
     name: Mapped[str]
-    submitted_name: Mapped[Optional[str]]
+
+    # @hybrid_property
+    # def submitted_name(self):
+    #     return self.name
+    #
+    # @submitted_name.expression
+    # def submitted_name(cls):
+    #     return cls.name
+
     homepage_url: Mapped[Optional[str]]
     jurisdiction_type: Mapped[JurisdictionTypeLiteral]
     state_iso: Mapped[Optional[str]]
     municipality: Mapped[Optional[str]]
-    county_fips: Mapped[Optional[str]] = mapped_column(
-        ForeignKey("public.counties.fips")
-    )
+    county_fips: Mapped[Optional[str]]
     county_name: Mapped[Optional[str]]
     lat: Mapped[Optional[float]]
     lng: Mapped[Optional[float]]
@@ -255,6 +264,8 @@ class AgencyExpanded(Agency):
 
     __tablename__ = Relations.AGENCIES_EXPANDED.value
     id = mapped_column(None, ForeignKey("public.agencies.id"), primary_key=True)
+
+    submitted_name = Column(String)
 
     state_name = Column(String)  #
     locality_name = Column(String)  #

--- a/middleware/schema_and_dto_logic/primary_resource_dtos/agencies_dtos.py
+++ b/middleware/schema_and_dto_logic/primary_resource_dtos/agencies_dtos.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel
 
 
 class AgencyInfoPutDTO(BaseModel):
-    submitted_name: str = None
+    name: str = None
     jurisdiction_type: JurisdictionType = None
     agency_type: AgencyType = AgencyType.NONE
     multi_agency: bool = False
@@ -26,7 +26,7 @@ class AgencyInfoPutDTO(BaseModel):
 
 
 class AgencyInfoPostDTO(BaseModel):
-    submitted_name: str
+    name: str
     jurisdiction_type: JurisdictionType
     agency_type: AgencyType
     multi_agency: bool = False

--- a/middleware/schema_and_dto_logic/primary_resource_schemas/agencies_advanced_schemas.py
+++ b/middleware/schema_and_dto_logic/primary_resource_schemas/agencies_advanced_schemas.py
@@ -19,7 +19,7 @@ from middleware.schema_and_dto_logic.primary_resource_dtos.agencies_dtos import 
     AgencyInfoPostDTO,
 )
 from middleware.schema_and_dto_logic.primary_resource_schemas.agencies_base_schemas import (
-    get_submitted_name_field,
+    get_name_field,
     get_jurisdiction_type_field,
     AgencyInfoBaseSchema,
     AgenciesExpandedSchema,
@@ -35,12 +35,12 @@ from utilities.enums import SourceMappingEnum
 
 
 class AgencyInfoPostSchema(AgencyInfoBaseSchema):
-    submitted_name = get_submitted_name_field(required=True)
+    name = get_name_field(required=True)
     jurisdiction_type = get_jurisdiction_type_field(required=True)
 
 
 class AgencyInfoPutSchema(AgencyInfoBaseSchema):
-    submitted_name = get_submitted_name_field(required=False)
+    name = get_name_field(required=False)
     jurisdiction_type = get_jurisdiction_type_field(required=False)
 
 

--- a/middleware/schema_and_dto_logic/primary_resource_schemas/agencies_base_schemas.py
+++ b/middleware/schema_and_dto_logic/primary_resource_schemas/agencies_base_schemas.py
@@ -10,7 +10,7 @@ from middleware.schema_and_dto_logic.enums import CSVColumnCondition
 from utilities.enums import SourceMappingEnum
 
 
-def get_submitted_name_field(required: bool) -> fields.Str:
+def get_name_field(required: bool) -> fields.Str:
     return fields.Str(
         required=required,
         metadata={
@@ -154,14 +154,12 @@ class AgenciesExpandedSchema(AgencyInfoBaseSchema):
             "source": SourceMappingEnum.JSON,
         },
     )
-    submitted_name = get_submitted_name_field(required=True)
+    submitted_name = get_name_field(required=True)
     jurisdiction_type = get_jurisdiction_type_field(required=True)
     name = fields.Str(
         required=False,
         metadata={
-            "description": "The name of the agency. If a state is provided, "
-            "concatenates `submitted_name` + ` - ` + `state_iso` "
-            "to help differentiate agencies with similar names.",
+            "description": "The name of the agency.",
             "source": SourceMappingEnum.JSON,
         },
     )

--- a/tests/alembic/AlembicRunner.py
+++ b/tests/alembic/AlembicRunner.py
@@ -1,0 +1,41 @@
+from dataclasses import dataclass
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import Connection, Inspector, MetaData, inspect, text
+from sqlalchemy.orm import scoped_session
+
+
+@dataclass
+class AlembicRunner:
+    connection: Connection
+    alembic_config: Config
+    inspector: Inspector
+    metadata: MetaData
+    session: scoped_session
+
+    def reflect(self):
+        self.metadata.clear()
+        self.metadata.reflect(bind=self.connection)
+        self.inspector = inspect(self.connection)
+
+    def upgrade(self, revision: str):
+        command.upgrade(self.alembic_config, revision)
+
+    def downgrade(self, revision: str):
+        print("Downgrading...")
+        command.downgrade(self.alembic_config, revision)
+
+    def stamp(self, revision: str):
+        command.stamp(self.alembic_config, revision)
+
+    def reset_schema(self):
+        self.connection.exec_driver_sql("DROP SCHEMA public CASCADE;")
+        self.connection.exec_driver_sql("CREATE SCHEMA public;")
+        self.connection.commit()
+
+    def execute(self, sql: str):
+        result = self.connection.execute(text(sql))
+        if result.cursor is not None:
+            results = result.fetchall()
+            self.connection.commit()
+            return results

--- a/tests/alembic/conftest.py
+++ b/tests/alembic/conftest.py
@@ -1,0 +1,55 @@
+import pytest
+from alembic.config import Config
+from sqlalchemy import create_engine, inspect, MetaData
+from sqlalchemy.orm import scoped_session, sessionmaker
+
+from conftest import get_alembic_conn_string
+from middleware.util import get_env_variable
+from tests.alembic.AlembicRunner import AlembicRunner
+
+
+@pytest.fixture()
+def alembic_config():
+    alembic_cfg = Config("alembic.ini")
+    yield alembic_cfg
+
+
+@pytest.fixture()
+def db_engine():
+    engine = create_engine(get_alembic_conn_string())
+    yield engine
+    engine.dispose()
+
+
+@pytest.fixture()
+def connection(db_engine):
+    connection = db_engine.connect()
+    yield connection
+    connection.close()
+
+
+@pytest.fixture()
+def alembic_runner(connection, alembic_config) -> AlembicRunner:
+    alembic_config.attributes["connection"] = connection
+    alembic_config.set_main_option("sqlalchemy.url", get_alembic_conn_string())
+    runner = AlembicRunner(
+        alembic_config=alembic_config,
+        inspector=inspect(connection),
+        metadata=MetaData(),
+        connection=connection,
+        session=scoped_session(sessionmaker(bind=connection)),
+    )
+    try:
+        runner.downgrade("base")
+    except Exception as e:
+        runner.reset_schema()
+        runner.stamp("base")
+    print("Running test")
+    yield runner
+    print("Test complete")
+    runner.session.close()
+    # try:
+    #     runner.downgrade("base")
+    # except Exception as e:
+    #     runner.reset_schema()
+    #     runner.stamp("base")

--- a/tests/alembic/helpers.py
+++ b/tests/alembic/helpers.py
@@ -1,0 +1,37 @@
+from typing import Optional
+
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from tests.alembic.AlembicRunner import AlembicRunner
+
+
+def get_enum_values(enum_name: str, session: Session) -> list[str]:
+    return session.execute(text(f"SELECT enum_range(NULL::{enum_name})")).scalar()
+
+
+def table_creation_check(
+    alembic_runner: AlembicRunner,
+    tables: list[str],
+    end_revision: str,
+    start_revision: Optional[str] = None,
+):
+    if start_revision is not None:
+        alembic_runner.upgrade(start_revision)
+    for table_name in tables:
+        assert table_name not in alembic_runner.inspector.get_table_names()
+    alembic_runner.upgrade(end_revision)
+    alembic_runner.reflect()
+    for table_name in tables:
+        assert table_name in alembic_runner.inspector.get_table_names()
+
+
+def columns_in_table(
+    alembic_runner: AlembicRunner,
+    table_name: str,
+    columns_to_check: list[str],
+) -> bool:
+    current_columns = [
+        col["name"] for col in alembic_runner.inspector.get_columns(table_name)
+    ]
+    return all(column in current_columns for column in columns_to_check)

--- a/tests/alembic/test_alembic_migrations.py
+++ b/tests/alembic/test_alembic_migrations.py
@@ -1,0 +1,60 @@
+from sqlalchemy import CursorResult
+
+from tests.alembic.AlembicRunner import AlembicRunner
+
+
+def test_submitted_name(alembic_runner: AlembicRunner):
+    alembic_runner.upgrade("12cf56cbebb7")
+    alembic_runner.execute(
+        """
+        INSERT INTO AGENCIES (
+        submitted_name,
+        state_iso,
+        jurisdiction_type
+        ) VALUES (
+        'Test Name',
+        'TX',
+        'state'
+        );    
+    """
+    )
+
+    results = alembic_runner.execute(
+        """
+        SELECT name, submitted_name FROM AGENCIES;
+    """
+    )
+
+    assert results[0][0] == "Test Name - TX"
+    assert results[0][1] == "Test Name"
+
+    def refresh_materialized_view():
+        alembic_runner.execute(
+            """
+            REFRESH MATERIALIZED VIEW TYPEAHEAD_AGENCIES;
+        """
+        )
+
+    refresh_materialized_view()
+    results = alembic_runner.execute(
+        """
+        SELECT name FROM typeahead_agencies;
+    """
+    )
+    assert results[0][0] == "Test Name - TX"
+
+    alembic_runner.upgrade("8ba99f12446d")
+    results = alembic_runner.execute(
+        """
+        SELECT name FROM AGENCIES;
+    """
+    )
+    assert results[0][0] == "Test Name"
+
+    refresh_materialized_view()
+    results = alembic_runner.execute(
+        """
+        SELECT name FROM typeahead_agencies;
+    """
+    )
+    assert results[0][0] == "Test Name"

--- a/tests/helper_scripts/complex_test_data_creation_functions.py
+++ b/tests/helper_scripts/complex_test_data_creation_functions.py
@@ -128,7 +128,7 @@ def get_sample_location_info(locality_name: Optional[str] = None) -> dict:
 
 
 def get_sample_agency_post_parameters(
-    submitted_name,
+    name,
     locality_name,
     jurisdiction_type: JurisdictionType,
     location_info: Optional[dict] = None,
@@ -148,7 +148,7 @@ def get_sample_agency_post_parameters(
         "agency_info": generate_test_data_from_schema(
             schema=AgencyInfoPostSchema(),
             override={
-                "submitted_name": submitted_name,
+                "name": name,
                 "jurisdiction_type": JurisdictionType.LOCAL.value,
             },
         ),

--- a/tests/helper_scripts/helper_classes/TestDataCreatorDBClient.py
+++ b/tests/helper_scripts/helper_classes/TestDataCreatorDBClient.py
@@ -115,7 +115,7 @@ class TestDataCreatorDBClient:
         )
         self.helper.delete_test_like(
             table_name=Relations.AGENCIES.value,
-            like_column_name="submitted_name",
+            like_column_name="name",
         )
         # Remove test data from locality
         self.helper.delete_test_like(
@@ -237,7 +237,7 @@ class TestDataCreatorDBClient:
     ) -> TestAgencyInfo:
         agency_name = self.test_name()
         column_value_mappings = {
-            "submitted_name": agency_name,
+            "name": agency_name,
             "jurisdiction_type": JurisdictionType.FEDERAL.value,
         }
         column_value_mappings.update(additional_column_value_mappings)

--- a/tests/helper_scripts/helper_classes/TestDataCreatorFlask.py
+++ b/tests/helper_scripts/helper_classes/TestDataCreatorFlask.py
@@ -114,7 +114,7 @@ class TestDataCreatorFlask:
             submitted_name = agency_name
         locality_name = self.tdcdb.test_name()
         sample_agency_post_parameters = get_sample_agency_post_parameters(
-            submitted_name=submitted_name,
+            name=submitted_name,
             locality_name=locality_name,
             jurisdiction_type=JurisdictionType.LOCAL,
             location_info=location_info,

--- a/tests/helper_scripts/helper_functions_complex.py
+++ b/tests/helper_scripts/helper_functions_complex.py
@@ -130,7 +130,7 @@ def setup_get_typeahead_suggestion_test_data(cursor: Optional[psycopg.Cursor] = 
         agency_id = db_client.create_or_get(
             table_name=Relations.AGENCIES.value,
             column_value_mappings={
-                "submitted_name": "Xylodammerung Police Agency",
+                "name": "Xylodammerung Police Agency",
                 "jurisdiction_type": JurisdictionType.STATE,
                 "location_id": location_id,
             },

--- a/tests/integration/test_agencies.py
+++ b/tests/integration/test_agencies.py
@@ -81,6 +81,8 @@ def test_agencies_get(test_data_creator_flask: TestDataCreatorFlask):
     assert data_asc != data_desc
     assert data_asc[0]["name"] < data_desc[0]["name"]
 
+    assert data_asc[0]["name"] == data_asc[0]["submitted_name"]
+
 
 def test_agencies_get_by_id(test_data_creator_flask: TestDataCreatorFlask):
     """
@@ -104,6 +106,7 @@ def test_agencies_get_by_id(test_data_creator_flask: TestDataCreatorFlask):
     )
 
     data = response_json["data"]
+    assert data["name"] == data["submitted_name"]
     assert data["id"] == int(agency_id)
     assert data["data_sources"][0]["id"] == int(cds.id)
 
@@ -140,7 +143,7 @@ def test_agencies_post(test_data_creator_flask: TestDataCreatorFlask):
 
     # Test with a new locality
     data_to_post = get_sample_agency_post_parameters(
-        submitted_name=get_test_name(),
+        name=get_test_name(),
         jurisdiction_type=JurisdictionType.LOCAL,
         locality_name=get_test_name(),
     )
@@ -172,7 +175,7 @@ def test_agencies_post(test_data_creator_flask: TestDataCreatorFlask):
 
     # Test with a new locality
     data_to_post = get_sample_agency_post_parameters(
-        submitted_name=get_test_name(),
+        name=get_test_name(),
         jurisdiction_type=JurisdictionType.LOCAL,
         locality_name="Capitola",
     )
@@ -185,7 +188,7 @@ def test_agencies_post(test_data_creator_flask: TestDataCreatorFlask):
     assert_contains_key_value_pairs(
         dict_to_check=json_data["data"],
         key_value_pairs={
-            "submitted_name": data_to_post["agency_info"]["submitted_name"],
+            "name": data_to_post["agency_info"]["name"],
             "state_iso": "PA",
             "county_name": "Allegheny",
             "locality_name": data_to_post["location_info"]["locality_name"],
@@ -197,7 +200,7 @@ def test_agencies_put(test_data_creator_flask: TestDataCreatorFlask):
     tdc = test_data_creator_flask
 
     data_to_post = get_sample_agency_post_parameters(
-        submitted_name=get_test_name(),
+        name=get_test_name(),
         jurisdiction_type=JurisdictionType.LOCAL,
         locality_name=get_test_name(),
     )
@@ -265,7 +268,7 @@ def test_agencies_delete(test_data_creator_flask: TestDataCreatorFlask):
         headers=admin_tus.jwt_authorization_header,
         json={
             "agency_info": {
-                "submitted_name": get_test_name(),
+                "name": get_test_name(),
                 "jurisdiction_type": JurisdictionType.FEDERAL.value,
             }
         },
@@ -283,7 +286,7 @@ def test_agencies_delete(test_data_creator_flask: TestDataCreatorFlask):
 
     results = tdc.db_client._select_from_relation(
         relation_name="agencies",
-        columns=["submitted_name"],
+        columns=["name"],
         where_mappings=[WhereMapping(column="id", value=int(agency_id))],
     )
 

--- a/tests/integration/test_bulk.py
+++ b/tests/integration/test_bulk.py
@@ -218,6 +218,7 @@ def test_batch_agencies_update_happy_path(
         rows=rows,
         request_validator_method=runner.tdc.request_validator.update_agencies_bulk,
     )
+    assert len(data["errors"]) == 0, f"Incorrect number of errors: {data['errors']}"
 
     ids = [agencies[i].id for i in range(3)]
 
@@ -273,6 +274,8 @@ def test_batch_data_sources_insert_happy_path(
     data_sources_post_runner: BatchTestRunner,
 ):
     runner = data_sources_post_runner
+    for _ in range(3):
+        runner.tdc.agency()
     rows = [
         runner.generate_test_data(override={"linked_agency_ids": [1, 2, 3]})
         for _ in range(3)

--- a/tests/integration/test_data_sources.py
+++ b/tests/integration/test_data_sources.py
@@ -205,6 +205,7 @@ def test_data_sources_by_id_get(test_data_creator_flask: TestDataCreatorFlask):
     assert data["name"] == cds.name
     assert data["data_requests"][0]["id"] == int(request_id)
     assert data["agencies"][0]["id"] == int(agency_id)
+    assert data["agencies"][0]["name"] == data["agencies"][0]["submitted_name"]
 
 
 def test_data_sources_by_id_put(test_data_creator_flask: TestDataCreatorFlask):

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -78,7 +78,7 @@ def test_agencies_post_schema():
     ):
         data = {
             "agency_info": {
-                "submitted_name": "test",
+                "name": "test",
                 "jurisdiction_type": jurisdiction_type.value,
             }
         }


### PR DESCRIPTION
### Fixes

* https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/596

### Description

1) Remove original `agencies.name`
2) Rename `agencies.submitted_name` to `agencies.name` 
3) API endpoints for `submitted_name` return same value as `name`, for backwards-compatibility.
4) Adjust tests

### Testing

* Run tests and confirm all function as expected

### Performance

* Impact marginal

### Docs

* Accompanying docs PRs, if applicable

### Breaking Changes

* `/agencies` `POST` and `PUT` may have their logic changed somewhat -- however, given that these are admin endpoints, this should be generally fine and only require slight adjustements.