### PR TITLE
Add migration to make agency_type non-null

### DIFF
--- a/alembic/versions/83090d813802_make_agency_type_non_null.py
+++ b/alembic/versions/83090d813802_make_agency_type_non_null.py
@@ -1,0 +1,28 @@
+"""make_agency_type_non_null
+
+Revision ID: 83090d813802
+Revises: 94da2c95b58d
+Create Date: 2025-02-11 10:05:49.486152
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '83090d813802'
+down_revision: Union[str, None] = '94da2c95b58d'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Add non-null constraint to agency_type
+    op.alter_column('agencies', 'agency_type', nullable=False)
+
+
+def downgrade() -> None:
+    # Remove non-null constraint from agency_type
+    op.alter_column('agencies', 'agency_type', nullable=True)

--- a/local_database/DataDumper/ENV.md
+++ b/local_database/DataDumper/ENV.md
@@ -6,3 +6,13 @@
 | `DUMP_PASSWORD` | The password of the user to connect to the database. | `HanviliciousHamiltonHilltops` |
 | `DUMP_DB_NAME`  | The name of the database to dump. | `source_collector_test_db`     |
 | `DUMP_PORT`     | The port of the database to dump.  | `5432`                         |
+
+Shell Script
+
+```env
+DUMP_HOST=127.0.0.1
+DUMP_USER=test_source_collector_user
+DUMP_PASSWORD=HanviliciousHamiltonHilltops
+DUMP_DB_NAME=source_collector_test_db
+DUMP_PORT=5432
+```


### PR DESCRIPTION
### Fixes

* https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/590

### Description

* Sets up constraint so that `agencies.agency_type` cannot be null.

### Testing

* Run all tests to confirm functionality. 

### Performance

* No performance impact

### Docs

* No documentation changes.

### Breaking Changes

* No breaking changes.
