### PR TITLE
Update API key to properly return 400 status code if API key not found

### DIFF
--- a/tests/integration/test_api_key.py
+++ b/tests/integration/test_api_key.py
@@ -1,5 +1,7 @@
 """Integration tests for /api_key endpoint"""
 
+from http import HTTPStatus
+
 from middleware.api_key import ApiKey
 from resources.ApiKeyResource import API_KEY_ROUTE
 from resources.endpoint_schema_config import SchemaConfigs
@@ -38,3 +40,20 @@ def test_api_key_post(test_data_creator_flask: TestDataCreatorFlask):
     assert (
         new_user_info.api_key == api_key.key_hash
     ), "API key returned not aligned with user API key in database"
+
+
+def test_api_key_not_found(test_data_creator_flask: TestDataCreatorFlask):
+    """
+    If an API key is not found, a proper error message should be returned
+    indicating that the API key is not valid
+    """
+    tdc = test_data_creator_flask
+
+    # We will use the `/agencies` `GET` endpoint as an example
+    response_json = run_and_validate_request(
+        flask_client=tdc.flask_client,
+        http_method="get",
+        endpoint="/agencies",
+        headers={"Authorization": "Basic bad_api_key"},
+        expected_response_status=HTTPStatus.UNAUTHORIZED,
+    )

--- a/tests/integration/test_reset_password.py
+++ b/tests/integration/test_reset_password.py
@@ -55,7 +55,7 @@ def test_reset_password_post(
     tdc.request_validator.get(
         endpoint=DATA_SOURCES_BASE_ENDPOINT,
         headers=get_authorization_header(scheme="Bearer", token=token),
-        expected_response_status=HTTPStatus.BAD_REQUEST,
+        expected_response_status=HTTPStatus.UNAUTHORIZED,
     )
 
     new_password = str(uuid.uuid4())


### PR DESCRIPTION
### Fixes

* https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/595

### Description

* Update endpoints accepting an API key to properly return a `400 UNAUTHORIZED` status code when an invalid API key is used
* Created test to additionally test this.

### Testing

* Run tests in tests directory, and confirm all function as expected

### Performance

* Impact marginal
* Slight increase in test overhead

### Docs

* No changes to documentation

### Breaking Changes

* No breaking changes