### PR TITLE
Remove redundant agency location columns

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -9,7 +9,7 @@ script_location = alembic
 # Uncomment the line below if you want the files to be prepended with date and time
 # see https://alembic.sqlalchemy.org/en/latest/tutorial.html#editing-the-ini-file
 # for all available tokens
-# file_template = %%(year)d_%%(month).2d_%%(day).2d_%%(hour).2d%%(minute).2d-%%(rev)s_%%(slug)s
+file_template = %%(year)d_%%(month).2d_%%(day).2d_%%(hour).2d%%(minute).2d-%%(rev)s_%%(slug)s
 
 # sys.path path, will be prepended to sys.path if present.
 # defaults to the current working directory.

--- a/alembic/versions/2025_02_13_1226-8cbea64afdb2_remove_agency_state_county_and_.py
+++ b/alembic/versions/2025_02_13_1226-8cbea64afdb2_remove_agency_state_county_and_.py
@@ -1,0 +1,87 @@
+"""Remove agency state county and municipality columns
+
+Revision ID: 8cbea64afdb2
+Revises: 0d9b984683a5
+Create Date: 2025-02-13 12:26:39.056537
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "8cbea64afdb2"
+down_revision: Union[str, None] = "0d9b984683a5"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.drop_column(
+        table_name="agencies",
+        column_name="state_iso",
+    )
+    op.drop_column(
+        table_name="agencies",
+        column_name="county_fips",
+    )
+    op.drop_column(
+        table_name="agencies",
+        column_name="county_name",
+    )
+    op.drop_column(
+        table_name="agencies",
+        column_name="municipality",
+    )
+    op.execute(
+        """DELETE FROM relation_column
+         WHERE relation = 'agencies' AND 
+         associated_column IN ('state_iso', 'county_fips', 'county_name', 'municipality');
+         """
+    )
+
+
+def downgrade() -> None:
+    op.add_column(
+        table_name="agencies",
+        column=sa.Column(
+            "municipality", sa.VARCHAR(), autoincrement=False, nullable=True
+        ),
+    )
+    op.add_column(
+        table_name="agencies",
+        column=sa.Column(
+            "county_name", sa.VARCHAR(), autoincrement=False, nullable=True
+        ),
+    )
+    op.add_column(
+        table_name="agencies",
+        column=sa.Column(
+            "county_fips", sa.VARCHAR(), autoincrement=False, nullable=True
+        ),
+    )
+    op.add_column(
+        table_name="agencies",
+        column=sa.Column("state_iso", sa.VARCHAR(), autoincrement=False, nullable=True),
+    )
+
+    op.execute(
+        """
+        With inserted_rows as (
+            INSERT INTO relation_column (relation, associated_column)
+             VALUES 
+                ('agencies', 'municipality'), 
+                ('agencies', 'county_name'), 
+                ('agencies', 'county_fips'), 
+                ('agencies', 'state_iso')
+             RETURNING id
+        )
+        INSERT INTO COLUMN_PERMISSION(rc_id, relation_role, access_permission)
+        SELECT id, 'STANDARD'::relation_role, 'READ'::access_permission FROM inserted_rows
+        UNION ALL
+        SELECT id, 'ADMIN'::relation_role, 'READ'::access_permission FROM inserted_rows;
+        """
+    )

--- a/database_client/models.py
+++ b/database_client/models.py
@@ -236,10 +236,6 @@ class Agency(Base, CountMetadata):
 
     homepage_url: Mapped[Optional[str]]
     jurisdiction_type: Mapped[JurisdictionTypeLiteral]
-    state_iso: Mapped[Optional[str]]
-    municipality: Mapped[Optional[str]]
-    county_fips: Mapped[Optional[str]]
-    county_name: Mapped[Optional[str]]
     lat: Mapped[Optional[float]]
     lng: Mapped[Optional[float]]
     defunct_year: Mapped[Optional[str]]
@@ -269,6 +265,10 @@ class AgencyExpanded(Agency):
 
     state_name = Column(String)  #
     locality_name = Column(String)  #
+    state_iso: Mapped[Optional[str]]
+    municipality: Mapped[Optional[str]]
+    county_fips: Mapped[Optional[str]]
+    county_name: Mapped[Optional[str]]
 
     # Some attributes need to be overwritten by the attributes provided by locations_expanded
     state_iso = Column(String)


### PR DESCRIPTION
### Fixes

* https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/614

### Description

* Remove redundant location columns from `agencies` (`municipality_name`, `state_iso`, `county_fips`, `county_name`)

### Testing

* Run tests and confirm functionality 

### Performance

* Impact marginal

### Docs

* No change 

### Breaking Changes

* No breaking changes.

