### PR TITLE
Mc 614 remove zip code and `county_airtable_uid`

### DIFF
--- a/alembic/versions/2025_02_13_1329-dd2295f7225e_remove_agency_zip_code_column.py
+++ b/alembic/versions/2025_02_13_1329-dd2295f7225e_remove_agency_zip_code_column.py
@@ -22,6 +22,7 @@ depends_on: Union[str, Sequence[str], None] = None
 def upgrade() -> None:
     op.execute("DROP VIEW IF EXISTS public.agencies_expanded;")
     op.drop_column(table_name="agencies", column_name="zip_code")
+    op.drop_column(table_name="agencies", column_name="county_airtable_uid")
     op.execute(
         """
     CREATE OR REPLACE VIEW public.agencies_expanded
@@ -66,6 +67,15 @@ def downgrade() -> None:
     op.add_column(
         table_name="agencies",
         column=sa.Column("zip_code", sa.VARCHAR(), autoincrement=False, nullable=True),
+    )
+    op.add_column(
+        table_name="agencies",
+        column=sa.Column(
+            "county_airtable_uid",
+            sa.VARCHAR(),
+            autoincrement=False,
+            nullable=True,
+        ),
     )
 
     op.execute(

--- a/alembic/versions/2025_02_13_1329-dd2295f7225e_remove_agency_zip_code_column.py
+++ b/alembic/versions/2025_02_13_1329-dd2295f7225e_remove_agency_zip_code_column.py
@@ -1,0 +1,117 @@
+"""Remove agency zip code column
+
+Revision ID: dd2295f7225e
+Revises: 8cbea64afdb2
+Create Date: 2025-02-13 13:29:50.184101
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "dd2295f7225e"
+down_revision: Union[str, None] = "8cbea64afdb2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("DROP VIEW IF EXISTS public.agencies_expanded;")
+    op.drop_column(table_name="agencies", column_name="zip_code")
+    op.execute(
+        """
+    CREATE OR REPLACE VIEW public.agencies_expanded
+     AS
+     SELECT a.name,
+        a.name AS submitted_name,
+        a.homepage_url,
+        a.jurisdiction_type,
+        l.state_iso,
+        l.state_name,
+        l.county_fips,
+        l.county_name,
+        a.lat,
+        a.lng,
+        a.defunct_year,
+        a.id,
+        a.agency_type,
+        a.multi_agency,
+        a.no_web_presence,
+        a.airtable_agency_last_modified,
+        a.approved,
+        a.rejection_reason,
+        a.last_approval_editor,
+        a.submitter_contact,
+        a.agency_created,
+        l.locality_name
+       FROM agencies a
+         LEFT JOIN locations_expanded l ON a.location_id = l.id;
+    """
+    )
+
+    op.execute(
+        """DELETE FROM relation_column
+         WHERE (relation = 'agencies' or relation = 'agencies_expanded') AND 
+         associated_column = 'zip_code';
+         """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP VIEW IF EXISTS public.agencies_expanded;")
+    op.add_column(
+        table_name="agencies",
+        column=sa.Column("zip_code", sa.VARCHAR(), autoincrement=False, nullable=True),
+    )
+
+    op.execute(
+        """
+    CREATE OR REPLACE VIEW public.agencies_expanded
+     AS
+     SELECT a.name,
+        a.name AS submitted_name,
+        a.homepage_url,
+        a.jurisdiction_type,
+        l.state_iso,
+        l.state_name,
+        l.county_fips,
+        l.county_name,
+        a.lat,
+        a.lng,
+        a.defunct_year,
+        a.id,
+        a.agency_type,
+        a.multi_agency,
+        a.zip_code,
+        a.no_web_presence,
+        a.airtable_agency_last_modified,
+        a.approved,
+        a.rejection_reason,
+        a.last_approval_editor,
+        a.submitter_contact,
+        a.agency_created,
+        l.locality_name
+       FROM agencies a
+         LEFT JOIN locations_expanded l ON a.location_id = l.id;
+    """
+    )
+
+    op.execute(
+        """
+        With inserted_rows as (
+            INSERT INTO relation_column (relation, associated_column)
+             VALUES 
+                ('agencies', 'zip_code'), 
+                ('agencies_expanded', 'zip_code')
+            RETURNING id
+        )
+        INSERT INTO COLUMN_PERMISSION(rc_id, relation_role, access_permission)
+        SELECT id, 'STANDARD'::relation_role, 'READ'::access_permission FROM inserted_rows
+        UNION ALL
+        SELECT id, 'ADMIN'::relation_role, 'READ'::access_permission FROM inserted_rows;
+        """
+    )

--- a/database_client/models.py
+++ b/database_client/models.py
@@ -225,15 +225,6 @@ class Agency(Base, CountMetadata):
 
     id: Mapped[int] = mapped_column(primary_key=True)
     name: Mapped[str]
-
-    # @hybrid_property
-    # def submitted_name(self):
-    #     return self.name
-    #
-    # @submitted_name.expression
-    # def submitted_name(cls):
-    #     return cls.name
-
     homepage_url: Mapped[Optional[str]]
     jurisdiction_type: Mapped[JurisdictionTypeLiteral]
     lat: Mapped[Optional[float]]
@@ -241,7 +232,6 @@ class Agency(Base, CountMetadata):
     defunct_year: Mapped[Optional[str]]
     agency_type: Mapped[Optional[str]]
     multi_agency: Mapped[bool] = mapped_column(server_default=false())
-    zip_code: Mapped[Optional[str]]
     no_web_presence: Mapped[bool] = mapped_column(server_default=false())
     airtable_agency_last_modified: Mapped[timestamp_tz] = mapped_column(
         server_default=func.current_timestamp()

--- a/middleware/schema_and_dto_logic/primary_resource_dtos/agencies_dtos.py
+++ b/middleware/schema_and_dto_logic/primary_resource_dtos/agencies_dtos.py
@@ -19,7 +19,6 @@ class AgencyInfoPutDTO(BaseModel):
     lat: float = None
     lng: float = None
     defunct_year: str = None
-    zip_code: str = None
     rejection_reason: str = None
     last_approval_editor: str = None
     submitter_contact: str = None
@@ -36,7 +35,6 @@ class AgencyInfoPostDTO(BaseModel):
     lat: Optional[float] = None
     lng: Optional[float] = None
     defunct_year: Optional[str] = None
-    zip_code: Optional[str] = None
     rejection_reason: Optional[str] = None
     last_approval_editor: Optional[str] = None
     submitter_contact: Optional[str] = None

--- a/middleware/schema_and_dto_logic/primary_resource_schemas/agencies_base_schemas.py
+++ b/middleware/schema_and_dto_logic/primary_resource_schemas/agencies_base_schemas.py
@@ -90,17 +90,6 @@ class AgencyInfoBaseSchema(Schema):
             "csv_column_name": CSVColumnCondition.SAME_AS_FIELD,
         },
     )
-    zip_code = fields.Str(
-        required=False,
-        allow_none=True,
-        metadata={
-            "description": "The zip code of the agency's location.",
-            "source": SourceMappingEnum.JSON,
-            "csv_column_name": CSVColumnCondition.SAME_AS_FIELD,
-        },
-        # TODO: Re-enable when all zip codes are of expected length
-        # validate=validate.Length(min=5),
-    )
     no_web_presence = fields.Bool(
         required=False,
         load_default=False,

--- a/relation_access_permissions/relation_configurations/agencies.csv
+++ b/relation_access_permissions/relation_configurations/agencies.csv
@@ -11,7 +11,6 @@ lng,WRITE,READ
 defunct_year,WRITE,READ
 agency_type,WRITE,READ
 multi_agency,WRITE,READ
-zip_code,WRITE,READ
 no_web_presence,WRITE,READ
 airtable_agency_last_modified,READ,READ
 approved,WRITE,READ

--- a/relation_access_permissions/relation_configurations/agencies.csv
+++ b/relation_access_permissions/relation_configurations/agencies.csv
@@ -18,7 +18,6 @@ rejection_reason,WRITE,READ
 last_approval_editor,WRITE,READ
 submitter_contact,WRITE,READ
 agency_created,READ,READ
-county_airtable_uid,READ,READ
 municipality,READ,READ
 location_id,WRITE,READ
 id,READ,READ

--- a/relation_access_permissions/relation_configurations/agencies_expanded.csv
+++ b/relation_access_permissions/relation_configurations/agencies_expanded.csv
@@ -11,7 +11,6 @@ lng,WRITE,READ
 defunct_year,WRITE,READ
 agency_type,WRITE,READ
 multi_agency,WRITE,READ
-zip_code,WRITE,READ
 no_web_presence,WRITE,READ
 airtable_agency_last_modified,READ,READ
 approved,WRITE,READ

--- a/resources/HomepageSearchCache.py
+++ b/resources/HomepageSearchCache.py
@@ -43,7 +43,6 @@ get_result_model = namespace_homepage_search_cache.model(
         "county_name": fields.String(description="The name of the county"),
         "airtable_uid": fields.String(description="The Airtable UID of the agency"),
         "count_data_sources": fields.Integer(description="The count of data sources"),
-        "zip_code": fields.String(description="The ZIP code of the agency"),
         "no_web_presence": fields.Boolean(
             description="Indicates if the agency has no web presence"
         ),


### PR DESCRIPTION
### Fixes

* https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/614

### Description

* Remove `zip_code` and `county_airtable_uid` columns from `agencies`

### Testing

* Run tests to confirm functionality

### Performance

* Impact marginal

### Docs

* Update to API: `zip_code` property removed from `/agencies` endpoints

### Breaking Changes

* `zip_code` column has been removed from schema. This may impact data downstream. @joshuagraber 