### PR TITLE
feat(api): add limit parameter to select endpoints

### DIFF
--- a/database_client/database_client.py
+++ b/database_client/database_client.py
@@ -875,6 +875,7 @@ class DatabaseClient:
         """
         Selects a single relation from the database
         """
+        limit = min(limit, 100)
         where_mappings = self._create_where_mappings_instance_if_dictionary(
             where_mappings
         )

--- a/middleware/primary_resource_logic/agencies.py
+++ b/middleware/primary_resource_logic/agencies.py
@@ -56,6 +56,7 @@ def get_agencies(
                 "order_by": OrderByParameters.construct_from_args(
                     sort_by=dto.sort_by, sort_order=dto.sort_order
                 ),
+                "limit": dto.limit,
             },
             subquery_parameters=SUBQUERY_PARAMS,
         ),

--- a/middleware/primary_resource_logic/data_requests.py
+++ b/middleware/primary_resource_logic/data_requests.py
@@ -187,7 +187,9 @@ def get_data_requests_wrapper(
         "order_by": OrderByParameters.construct_from_args(
             sort_by=dto.sort_by, sort_order=dto.sort_order
         ),
+        "limit": dto.limit,
     }
+
     if dto.request_statuses is not None:
         db_client_additional_args["where_mappings"] = {
             "request_status": [rs.value for rs in dto.request_statuses]
@@ -225,6 +227,7 @@ def get_data_requests_with_permitted_columns(
         order_by=OrderByParameters.construct_from_args(dto.sort_by, dto.sort_order),
         subquery_parameters=get_data_requests_subquery_params(),
         build_metadata=build_metadata,
+        limit=dto.limit,
     )
     return data_requests
 

--- a/middleware/primary_resource_logic/data_sources_logic.py
+++ b/middleware/primary_resource_logic/data_sources_logic.py
@@ -85,6 +85,7 @@ def get_data_sources_wrapper(
                     )
                 ],
                 "build_metadata": True,
+                "limit": dto.limit,
             },
             entry_name="data source",
             subquery_parameters=SUBQUERY_PARAMS,

--- a/middleware/schema_and_dto_logic/common_schemas_and_dtos.py
+++ b/middleware/schema_and_dto_logic/common_schemas_and_dtos.py
@@ -9,6 +9,7 @@ from typing import Optional
 from marshmallow import Schema, fields, validate
 from pydantic import BaseModel
 
+from database_client.constants import PAGE_SIZE
 from database_client.enums import SortOrder, LocationType
 from middleware.schema_and_dto_logic.custom_fields import DataField
 from middleware.schema_and_dto_logic.non_dto_dataclasses import (
@@ -56,6 +57,14 @@ class GetManyRequestsBaseSchema(Schema):
             "description": "A comma-delimited list of the columns to return in the results. Defaults to all permitted if not provided.",
         },
     )
+    limit = fields.Integer(
+        required=False,
+        load_default=100,
+        metadata={
+            "source": SourceMappingEnum.QUERY_ARGS,
+            "description": "The maximum number of results to return. Defaults to 100 if not provided.",
+        },
+    )
 
 
 class GetManyBaseDTO(BaseModel):
@@ -67,6 +76,7 @@ class GetManyBaseDTO(BaseModel):
     sort_by: Optional[str] = None
     sort_order: Optional[SortOrder] = None
     requested_columns: Optional[list[str]] = None
+    limit: Optional[int] = PAGE_SIZE
 
 
 GET_MANY_SCHEMA_POPULATE_PARAMETERS = SchemaPopulateParameters(

--- a/tests/helper_scripts/helper_classes/RequestValidator.py
+++ b/tests/helper_scripts/helper_classes/RequestValidator.py
@@ -10,6 +10,7 @@ from typing import Optional, Type, Union, List
 from flask.testing import FlaskClient
 from marshmallow import Schema
 
+from database_client.constants import PAGE_SIZE
 from database_client.enums import SortOrder, RequestStatus, ApprovalStatus
 from middleware.enums import OutputFormatEnum, PermissionsEnum
 from middleware.util import update_if_not_none
@@ -414,6 +415,7 @@ class RequestValidator:
         sort_by: Optional[str] = None,
         sort_order: Optional[SortOrder] = None,
         request_statuses: Optional[list[RequestStatus]] = None,
+        limit: Optional[int] = PAGE_SIZE,
     ):
         query_params = {}
         update_if_not_none(
@@ -426,6 +428,7 @@ class RequestValidator:
                     if request_statuses is not None
                     else None
                 ),
+                "limit": limit,
             },
         )
         return self.get(
@@ -505,21 +508,34 @@ class RequestValidator:
         )
 
     def get_user_profile_data_requests(
-        self, headers: dict, expected_json_content: Optional[dict] = None
+        self,
+        headers: dict,
+        expected_json_content: Optional[dict] = None,
+        limit: int = PAGE_SIZE,
     ):
         return self.get(
-            endpoint="/api/user/data-requests?page=1",
+            endpoint=f"/api/user/data-requests?page=1&limit={limit}",
             headers=headers,
             expected_json_content=expected_json_content,
             expected_schema=SchemaConfigs.USER_PROFILE_DATA_REQUESTS_GET.value.primary_output_schema,
         )
 
     def get_agency(
-        self, sort_by: str, sort_order: SortOrder, headers: dict, page: int = 1
+        self,
+        sort_by: str,
+        sort_order: SortOrder,
+        headers: dict,
+        page: int = 1,
+        limit: int = PAGE_SIZE,
     ):
         url = add_query_params(
             url=AGENCIES_BASE_ENDPOINT,
-            params={"sort_by": sort_by, "sort_order": sort_order.value, "page": page},
+            params={
+                "sort_by": sort_by,
+                "sort_order": sort_order.value,
+                "page": page,
+                "limit": limit,
+            },
         )
         return self.get(
             endpoint=url,
@@ -604,6 +620,34 @@ class RequestValidator:
             file=bop.file,
             expected_schema=expected_schema,
             expected_response_status=bop.expected_response_status,
+        )
+
+    def get_data_sources(
+        self,
+        headers: dict,
+        sort_by: Optional[str] = None,
+        sort_order: Optional[SortOrder] = None,
+        page: int = 1,
+        limit: int = PAGE_SIZE,
+        approval_status: ApprovalStatus = ApprovalStatus.APPROVED,
+    ):
+        query_params = {}
+        update_if_not_none(
+            dict_to_update=query_params,
+            secondary_dict={
+                "sort_by": sort_by,
+                "sort_order": sort_order.value if sort_order is not None else None,
+                "page": page,
+                "limit": limit,
+                "approval_status": approval_status.value,
+            },
+        )
+
+        return self.get(
+            endpoint=DATA_SOURCES_BASE_ENDPOINT,
+            query_parameters=query_params,
+            headers=headers,
+            expected_schema=SchemaConfigs.DATA_SOURCES_GET_MANY.value.primary_output_schema,
         )
 
     def get_agency_by_id(self, headers: dict, id: int):

--- a/tests/integration/test_agencies.py
+++ b/tests/integration/test_agencies.py
@@ -83,6 +83,20 @@ def test_agencies_get(test_data_creator_flask: TestDataCreatorFlask):
 
     assert data_asc[0]["name"] == data_asc[0]["submitted_name"]
 
+    # Test limit functionality
+    response_json = tdc.request_validator.get_agency(
+        headers=tus.api_authorization_header,
+        sort_by="name",
+        sort_order=SortOrder.ASCENDING,
+        limit=1,
+    )
+
+    assert_expected_get_many_result(
+        response_json=response_json,
+        expected_non_null_columns=["id"],
+    )
+    assert len(response_json["data"]) == 1
+
 
 def test_agencies_get_by_id(test_data_creator_flask: TestDataCreatorFlask):
     """

--- a/tests/integration/test_data_requests.py
+++ b/tests/integration/test_data_requests.py
@@ -126,6 +126,14 @@ def test_data_requests_get(
 
     assert int(data_asc[0]["id"]) < int(data_desc[0]["id"])
 
+    # Test limit
+    data = tdc.request_validator.get_data_requests(
+        headers=tus_creator.jwt_authorization_header,
+        limit=1,
+    )[DATA_KEY]
+
+    assert len(data) == 1
+
 
 def test_data_requests_post(
     test_data_creator_flask: TestDataCreatorFlask,

--- a/tests/integration/test_data_sources.py
+++ b/tests/integration/test_data_sources.py
@@ -13,6 +13,7 @@ from database_client.enums import (
     URLStatus,
     ApprovalStatus,
     UpdateMethod,
+    SortOrder,
 )
 from middleware.enums import RecordType
 from middleware.schema_and_dto_logic.primary_resource_schemas.data_sources_base_schemas import (
@@ -52,35 +53,36 @@ def test_data_sources_get(
     tus = tdc.standard_user()
     for i in range(100):
         test_data_creator_db_client.data_source(approval_status=ApprovalStatus.APPROVED)
-    response_json = run_and_validate_request(
-        flask_client=tdc.flask_client,
-        http_method="get",
-        endpoint=f"{DATA_SOURCES_BASE_ENDPOINT}?page=1&approval_status=approved",  # ENDPOINT,
+    response_json = tdc.request_validator.get_data_sources(
         headers=tus.api_authorization_header,
-        expected_schema=SchemaConfigs.DATA_SOURCES_GET_MANY.value.primary_output_schema,
     )
     data = response_json["data"]
     assert len(data) == 100
 
     # Test sort functionality
-    response_json = run_and_validate_request(
-        flask_client=tdc.flask_client,
-        http_method="get",
-        endpoint=f"{DATA_SOURCES_BASE_ENDPOINT}?page=1&sort_by=name&sort_order=ASC&approval_status=approved",
+    response_json = tdc.request_validator.get_data_sources(
         headers=tus.api_authorization_header,
-        expected_schema=SchemaConfigs.DATA_SOURCES_GET_MANY.value.primary_output_schema,
+        sort_by="name",
+        sort_order=SortOrder.ASCENDING,
     )
     data_asc = response_json["data"]
 
-    response_json = run_and_validate_request(
-        flask_client=tdc.flask_client,
-        http_method="get",
-        endpoint=f"{DATA_SOURCES_BASE_ENDPOINT}?page=1&sort_by=name&sort_order=DESC&approval_status=approved",
+    response_json = tdc.request_validator.get_data_sources(
         headers=tus.api_authorization_header,
+        sort_by="name",
+        sort_order=SortOrder.DESCENDING,
     )
     data_desc = response_json["data"]
 
     assert data_asc[0]["name"] < data_desc[0]["name"]
+
+    # Test limit functionality
+    response_json = tdc.request_validator.get_data_sources(
+        headers=tus.api_authorization_header,
+        limit=10,
+    )
+    data = response_json["data"]
+    assert len(data) == 10
 
 
 def test_data_sources_get_many_limit_columns(

--- a/tests/integration/test_user_profile.py
+++ b/tests/integration/test_user_profile.py
@@ -35,6 +35,25 @@ def test_user_profile_data_requests(test_data_creator_flask: TestDataCreatorFlas
     assert json_response["data"][0]["id"] == int(tdr.id)
     assert json_response["data"][0]["submission_notes"] == tdr.submission_notes
 
+    # Create additional data requests and confirm they are returned
+    create_test_data_request(tdc.flask_client, tus.jwt_authorization_header)
+    create_test_data_request(tdc.flask_client, tus.jwt_authorization_header)
+
+    json_response = tdc.request_validator.get_user_profile_data_requests(
+        headers=tus.jwt_authorization_header,
+    )
+
+    assert len(json_response["data"]) == 3
+
+    # Test limit
+
+    json_response = tdc.request_validator.get_user_profile_data_requests(
+        headers=tus.jwt_authorization_header,
+        limit=2,
+    )
+
+    assert len(json_response["data"]) == 2
+
 
 def test_user_profile_get_by_id(test_data_creator_flask: TestDataCreatorFlask):
     tdc = test_data_creator_flask


### PR DESCRIPTION
### Fixes

* https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/579

### Description

* Add limit parameter to the following `GET` endpoints
 * `/data-sources`
 * `/agencies`
 * `/data-requests`
 * `/user/data-requests`

### Testing

* Run tests to confirm functionality 
* Confirm presence of `limit` query parameter in the following endpoints in API documentation
* 
![image](https://github.com/user-attachments/assets/790515f1-2eaf-4876-8d4a-d326dea81fdd)

### Performance

* Impact marginal

### Docs

* `limit` query parameter added to endpoints

### Breaking Changes

* No breaking changes