### PR TITLE
feat(db_client): add fuzzy matching backup to typeahead location

### DIFF
--- a/database_client/dynamic_query_constructor.py
+++ b/database_client/dynamic_query_constructor.py
@@ -119,7 +119,27 @@ class DynamicQueryConstructor:
         ]
 
     @staticmethod
-    def generate_new_typeahead_locations_query(search_term: str):
+    def generate_fuzzy_match_typeahead_locations_query(
+        search_term: str,
+    ) -> sql.Composed:
+        query = sql.SQL(
+            """
+            SELECT 
+                display_name,
+                type,
+                state_name,
+                county_name,
+                locality_name,
+                location_id
+            FROM typeahead_locations
+            ORDER BY similarity(concat(locality_name, ' ', county_name, ' ', state_name), {search_term}) DESC
+            LIMIT 10
+            """
+        ).format(search_term=sql.Literal(search_term))
+        return query
+
+    @staticmethod
+    def generate_like_typeahead_locations_query(search_term: str) -> sql.Composed:
         query = sql.SQL(
             """
         WITH combined AS (

--- a/tests/helper_scripts/helper_classes/TestDataCreatorDBClient.py
+++ b/tests/helper_scripts/helper_classes/TestDataCreatorDBClient.py
@@ -2,6 +2,7 @@ import uuid
 from typing import Optional
 
 from sqlalchemy import delete, select, and_
+from sqlalchemy.exc import IntegrityError
 
 from database_client.database_client import DatabaseClient
 from database_client.enums import (
@@ -76,7 +77,10 @@ class TDCSQLAlchemyHelper:
         column_id = getattr(table, "id")
         query = select(column_id).where(column_name == state_iso)
         result = self.db_client.execute_sqlalchemy(lambda: query)
-        return [row[0] for row in result][0]
+        results = [result[0] for result in result]
+        if len(results) == 0:
+            raise Exception(f"Could not find state with iso {state_iso}")
+        return results[0]
 
     def clear_user_notification_queue(self):
         table = SQL_ALCHEMY_TABLE_REFERENCE[Relations.USER_NOTIFICATION_QUEUE.value]
@@ -136,6 +140,19 @@ class TestDataCreatorDBClient:
         )
 
         self.helper.clear_user_notification_queue()
+
+    def county(
+        self,
+        county_name: str,
+        state_iso: str = "PA",
+        fips: Optional[str] = None,
+    ) -> int:
+        state_id = self.helper.get_state_id(state_iso=state_iso)
+        if fips is None:
+            fips = str(get_random_number_for_testing())
+        return self.db_client.create_county(
+            name=county_name, fips=fips, state_id=state_id
+        )
 
     def locality(
         self,
@@ -298,6 +315,77 @@ class TestDataCreatorDBClient:
             external_account_type=ExternalAccountTypeEnum.GITHUB,
         )
         return fake_id
+
+    def create_states(self):
+        states = [
+            ["AL", "Alabama"],
+            ["AK", "Alaska"],
+            ["AZ", "Arizona"],
+            ["AR", "Arkansas"],
+            ["CA", "California"],
+            ["CZ", "Canal Zone"],
+            ["CO", "Colorado"],
+            ["CT", "Connecticut"],
+            ["DE", "Delaware"],
+            ["DC", "District of Columbia"],
+            ["FL", "Florida"],
+            ["GA", "Georgia"],
+            ["GU", "Guam"],
+            ["HI", "Hawaii"],
+            ["ID", "Idaho"],
+            ["IL", "Illinois"],
+            ["IN", "Indiana"],
+            ["IA", "Iowa"],
+            ["KS", "Kansas"],
+            ["KY", "Kentucky"],
+            ["LA", "Louisiana"],
+            ["ME", "Maine"],
+            ["MD", "Maryland"],
+            ["MA", "Massachusetts"],
+            ["MI", "Michigan"],
+            ["MN", "Minnesota"],
+            ["MS", "Mississippi"],
+            ["MO", "Missouri"],
+            ["MT", "Montana"],
+            ["NE", "Nebraska"],
+            ["NV", "Nevada"],
+            ["NH", "New Hampshire"],
+            ["NJ", "New Jersey"],
+            ["NM", "New Mexico"],
+            ["NY", "New York"],
+            ["NC", "North Carolina"],
+            ["ND", "North Dakota"],
+            ["OH", "Ohio"],
+            ["OK", "Oklahoma"],
+            ["OR", "Oregon"],
+            ["PA", "Pennsylvania"],
+            ["PR", "Puerto Rico"],
+            ["RI", "Rhode Island"],
+            ["SC", "South Carolina"],
+            ["SD", "South Dakota"],
+            ["TN", "Tennessee"],
+            ["TX", "Texas"],
+            ["UT", "Utah"],
+            ["VT", "Vermont"],
+            ["VI", "Virgin Islands"],
+            ["VA", "Virginia"],
+            ["WA", "Washington"],
+            ["WV", "West Virginia"],
+            ["WI", "Wisconsin"],
+            ["WY", "Wyoming"],
+        ]
+        for state_abbr, state_name in states:
+            try:
+                self.db_client._create_entry_in_table(
+                    table_name=Relations.US_STATES.value,
+                    column_value_mappings={
+                        "state_name": state_name,
+                        "state_iso": state_abbr,
+                    },
+                )
+            except IntegrityError:
+                # Already exists. Keep going
+                pass
 
 
 class ValidNotificationEventCreator:

--- a/tests/helper_scripts/helper_classes/TestDataCreatorFlask.py
+++ b/tests/helper_scripts/helper_classes/TestDataCreatorFlask.py
@@ -133,6 +133,9 @@ class TestDataCreatorFlask:
     def refresh_typeahead_agencies(self):
         self.db_client.execute_raw_sql("CALL refresh_typeahead_agencies();")
 
+    def refresh_typeahead_locations(self):
+        self.db_client.execute_raw_sql("CALL refresh_typeahead_locations();")
+
     def update_agency(self, agency_id: int, data_to_update: dict):
         run_and_validate_request(
             flask_client=self.flask_client,

--- a/tests/integration/test_data_requests.py
+++ b/tests/integration/test_data_requests.py
@@ -1,6 +1,5 @@
 import uuid
 
-from dataclasses import dataclass
 from http import HTTPStatus
 from typing import Dict, Optional
 
@@ -9,7 +8,7 @@ from flask.testing import FlaskClient
 from database_client.db_client_dataclasses import WhereMapping
 from database_client.enums import RequestUrgency, LocationType, RequestStatus, SortOrder
 from middleware.constants import DATA_KEY
-from middleware.enums import PermissionsEnum, RecordType
+from middleware.enums import RecordType
 from middleware.util import get_enum_values
 from resources.endpoint_schema_config import SchemaConfigs
 from tests.helper_scripts.common_test_data import (
@@ -28,14 +27,13 @@ from tests.helper_scripts.constants import (
     DATA_REQUESTS_GET_RELATED_SOURCE_ENDPOINT,
     DATA_REQUESTS_POST_DELETE_RELATED_SOURCE_ENDPOINT,
     DATA_REQUESTS_RELATED_LOCATIONS,
-    DATA_REQUESTS_POST_DELETE_RELATED_LOCATIONS_ENDPOINT,
 )
 
 from tests.helper_scripts.helper_classes.TestUserSetup import TestUserSetup
 
 from tests.helper_scripts.run_and_validate_request import run_and_validate_request
 
-from conftest import test_data_creator_flask, monkeysession
+from conftest import test_data_creator_flask
 
 
 def test_data_requests_get(

--- a/tests/integration/test_typeahead_suggestions.py
+++ b/tests/integration/test_typeahead_suggestions.py
@@ -53,6 +53,62 @@ def test_typeahead_locations(flask_client_with_db):
 
     assert suggestions == expected_suggestions
 
+    # Even the most absurd misspellings should pull back something
+    json_content = run_and_validate_request(
+        flask_client=flask_client_with_db,
+        http_method="get",
+        endpoint="/typeahead/locations?query=AbsolutelyGodawfulMisspelledEntryThatShouldMatchNothing",
+        expected_schema=TypeaheadLocationsOuterResponseSchema,
+    )
+    assert len(json_content["suggestions"]) >= 1
+
+
+def test_typeahead_locations_cleveland(test_data_creator_flask: TestDataCreatorFlask):
+    """
+    Test that GET call to /typeahead/locations endpoint successfully retrieves the correct
+    Cleveland in the notorious Cleveland Case,
+    where there are 17 Clevelands in the database
+    """
+    tdc = test_data_creator_flask
+    tdc.tdcdb.create_states()
+
+    clevelands = [
+        ["NC", "Rowan"],
+        ["WI", "Manitowoc"],
+        ["OK", "Pawnee"],
+        ["MO", "Cass"],
+        ["MN", "Le Sueur"],
+        ["MI", "Jackson"],
+        ["OR", "Multnomah"],
+        ["IN", "Washington"],
+        ["TX", "Liberty"],
+        ["AL", "Blount"],
+        ["OH", "Cuyahoga"],
+        ["TN", "Bradley"],
+        ["MS", "Bolivar"],
+        ["GA", "White"],
+    ]
+    for state_name, county_name in clevelands:
+        county_id = tdc.tdcdb.county(state_iso=state_name, county_name=county_name)
+        location_id = tdc.locality(
+            locality_name="Cleveland", county_name=county_name, state_iso=state_name
+        )
+    tdc.refresh_typeahead_locations()
+
+    json_content = run_and_validate_request(
+        flask_client=tdc.flask_client,
+        http_method="get",
+        endpoint="/typeahead/locations?query=cleveland ohio",
+        expected_schema=TypeaheadLocationsOuterResponseSchema,
+    )
+
+    assert len(json_content["suggestions"]) >= 1
+    result = json_content["suggestions"][0]
+
+    assert result["locality_name"] == "Cleveland"
+    assert result["county_name"] == "Cuyahoga"
+    assert result["state_name"] == "Ohio"
+
 
 def test_typeahead_agencies(test_data_creator_flask: TestDataCreatorFlask):
     """

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -610,6 +610,13 @@ def test_user_pending_notifications_view(
 
     tdc = test_data_creator_db_client
     tdc.clear_test_data()
+    tdc.create_states()
+
+    county_name = get_test_name()
+    tdc.county(
+        county_name=county_name,
+        state_iso="OH",
+    )
 
     location_both_following = tdc.locality()
     location_state_for_2 = tdc.db_client.get_location_id(
@@ -618,13 +625,13 @@ def test_user_pending_notifications_view(
     location_county_for_1 = tdc.db_client.get_location_id(
         where_mappings={
             "state_iso": "OH",
-            "county_name": "Cuyahoga",
+            "county_name": county_name,
             "type": LocationType.COUNTY.value,
         }
     )
 
     # These are both designed to be fake
-    locality_1_following = tdc.locality(state_iso="OH", county_name="Cuyahoga")
+    locality_1_following = tdc.locality(state_iso="OH", county_name=county_name)
     locality_2_following = tdc.locality(state_iso="CA", county_name="Orange")
 
     # Create two users


### PR DESCRIPTION
### Fixes

* https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/576

### Description

* Add fuzzy matching backup to `/typeahead/locations` search, which kicks in when the regular search returns either too few (0) or too many (>10) results to further refine.

### Testing

* Run tests and confirm all pass

### Performance

* Fuzzy matching backup, by its nature, is more computationally intensive than lighter searches. If the previous search logic returns between 1 and 10 (inclusive) results, this search is not run. Otherwise, it is performed.

### Docs

* No documentation updates

### Breaking Changes

* No breaking changes 