### PR TITLE
Mc 563 update post endpoints with location

### DIFF
--- a/middleware/primary_resource_logic/data_requests.py
+++ b/middleware/primary_resource_logic/data_requests.py
@@ -130,7 +130,7 @@ def create_data_request_wrapper(
     :return:
     """
     # Check that location ids are valid, and get location ids for linking
-    location_ids = _get_location_ids(db_client, dto)
+    location_ids = dto.location_ids if dto.location_ids is not None else []
 
     column_value_mappings_raw = dict(dto.request_info)
     user_id = access_info.get_user_id()
@@ -153,9 +153,9 @@ def create_data_request_wrapper(
 
 def _get_location_ids(db_client, dto: DataRequestsPostDTO):
     location_ids = []
-    if dto.location_infos is None:
+    if dto.location_ids is None:
         return location_ids
-    for location_info in dto.location_infos:
+    for location_info in dto.location_ids:
         try:
             location_id = get_location_id_for_data_requests(
                 db_client=db_client, location_info=location_info

--- a/middleware/schema_and_dto_logic/primary_resource_dtos/agencies_dtos.py
+++ b/middleware/schema_and_dto_logic/primary_resource_dtos/agencies_dtos.py
@@ -42,12 +42,12 @@ class AgencyInfoPostDTO(BaseModel):
 
 class AgenciesPostDTO(BaseModel):
     agency_info: AgencyInfoPostDTO
-    location_info: Optional[LocationInfoDTO] = None
+    location_id: Optional[int] = None
 
 
 class AgenciesPutDTO(BaseModel):
     agency_info: AgencyInfoPutDTO
-    location_info: Optional[LocationInfoDTO] = None
+    location_id: Optional[int] = None
 
 
 class RelatedAgencyByIDDTO(GetByIDBaseDTO):

--- a/middleware/schema_and_dto_logic/primary_resource_dtos/data_requests_dtos.py
+++ b/middleware/schema_and_dto_logic/primary_resource_dtos/data_requests_dtos.py
@@ -82,4 +82,4 @@ class RequestInfoPostDTO(BaseModel):
 
 class DataRequestsPostDTO(BaseModel):
     request_info: RequestInfoPostDTO
-    location_infos: Optional[list[DataRequestLocationInfoPostDTO]] = None
+    location_ids: Optional[list[int]] = None

--- a/middleware/schema_and_dto_logic/primary_resource_schemas/agencies_advanced_schemas.py
+++ b/middleware/schema_and_dto_logic/primary_resource_schemas/agencies_advanced_schemas.py
@@ -62,30 +62,26 @@ def get_agency_info_field(
 def validate_location_info_against_jurisdiction_type(data, jurisdiction_type):
     if (
         jurisdiction_type == JurisdictionType.FEDERAL
-        and data.get("location_info") is not None
+        and data.get("location_id") is not None
     ):
-        raise ValidationError(
-            "location_info must be None for jurisdiction type FEDERAL."
-        )
+        raise ValidationError("location_id must be None for jurisdiction type FEDERAL.")
     if (
         jurisdiction_type != JurisdictionType.FEDERAL
-        and data.get("location_info") is None
+        and data.get("location_id") is None
     ):
         raise ValidationError(
-            "location_info is required for non-FEDERAL jurisdiction type."
+            "location_id is required for non-FEDERAL jurisdiction type."
         )
 
 
 class AgenciesPostPutBaseSchema(Schema):
-    location_info = fields.Nested(
-        LocationInfoSchema,
+    location_id = fields.Integer(
         required=False,
         allow_none=True,
-        metadata={
-            "description": "The locational information of the agency. Must be None if agency is of jurisdiction_type `federal`",
-            "source": SourceMappingEnum.JSON,
-            "nested_dto_class": LocationInfoDTO,
-        },
+        load_default=None,
+        metadata=get_json_metadata(
+            description="The id of the location associated with the agency."
+        ),
     )
 
 

--- a/middleware/schema_and_dto_logic/primary_resource_schemas/agencies_advanced_schemas.py
+++ b/middleware/schema_and_dto_logic/primary_resource_schemas/agencies_advanced_schemas.py
@@ -11,6 +11,7 @@ from middleware.schema_and_dto_logic.common_schemas_and_dtos import (
     GetByIDBaseSchema,
     LocationInfoDTO,
 )
+from middleware.schema_and_dto_logic.enums import CSVColumnCondition
 from middleware.schema_and_dto_logic.primary_resource_schemas.locations_schemas import (
     LocationInfoSchema,
 )
@@ -80,7 +81,8 @@ class AgenciesPostPutBaseSchema(Schema):
         allow_none=True,
         load_default=None,
         metadata=get_json_metadata(
-            description="The id of the location associated with the agency."
+            description="The id of the location associated with the agency.",
+            csv_column_name=CSVColumnCondition.SAME_AS_FIELD,
         ),
     )
 

--- a/middleware/schema_and_dto_logic/primary_resource_schemas/data_requests_advanced_schemas.py
+++ b/middleware/schema_and_dto_logic/primary_resource_schemas/data_requests_advanced_schemas.py
@@ -117,26 +117,22 @@ class DataRequestsPostSchema(Schema):
         ),
         required=True,
     )
-    location_infos = fields.List(
-        fields.Nested(
-            nested=TypeaheadLocationsResponseSchema(
-                only=["type", "state_name", "county_name", "locality_name"]
-            ),
+    location_ids = fields.List(
+        fields.Integer(
             metadata=get_json_metadata(
-                "The locations associated with the data request",
-                nested_dto_class=DataRequestLocationInfoPostDTO,
+                "The location ids associated with the data request",
             ),
         ),
         required=False,
         allow_none=True,
-        metadata=get_json_metadata("The locations associated with the data request"),
+        metadata=get_json_metadata("The location ids associated with the data request"),
     )
 
     @post_load
-    def location_infos_convert_empty_list_to_none(self, in_data, **kwargs):
-        location_infos = in_data.get("location_infos", None)
-        if location_infos == []:
-            in_data["location_infos"] = None
+    def location_ids_convert_empty_list_to_none(self, in_data, **kwargs):
+        location_ids = in_data.get("location_ids", None)
+        if location_ids == []:
+            in_data["location_ids"] = None
         return in_data
 
 

--- a/tests/helper_scripts/complex_test_data_creation_functions.py
+++ b/tests/helper_scripts/complex_test_data_creation_functions.py
@@ -138,7 +138,7 @@ def get_sample_agency_post_parameters(
     """
 
     if location_info is None:
-        location_info = {
+        location_id = {
             "type": "Locality",
             "state_iso": "PA",
             "county_fips": "42003",
@@ -153,5 +153,5 @@ def get_sample_agency_post_parameters(
                 "agency_type": AgencyType.POLICE.value,
             },
         ),
-        "location_info": location_info,
+        "location_id": location_info,
     }

--- a/tests/integration/test_agencies.py
+++ b/tests/integration/test_agencies.py
@@ -211,7 +211,7 @@ def test_agencies_post(test_data_creator_flask: TestDataCreatorFlask):
 def test_agencies_put(test_data_creator_flask: TestDataCreatorFlask):
     tdc = test_data_creator_flask
 
-    data_to_post = get_sample_agency_post_parameters(
+    data_to_post = tdc.get_sample_agency_post_parameters(
         name=get_test_name(),
         jurisdiction_type=JurisdictionType.LOCAL,
         locality_name=get_test_name(),

--- a/tests/integration/test_agencies.py
+++ b/tests/integration/test_agencies.py
@@ -156,7 +156,7 @@ def test_agencies_post(test_data_creator_flask: TestDataCreatorFlask):
         )
 
     # Test with a new locality
-    data_to_post = get_sample_agency_post_parameters(
+    data_to_post = tdc.get_sample_agency_post_parameters(
         name=get_test_name(),
         jurisdiction_type=JurisdictionType.LOCAL,
         locality_name=get_test_name(),
@@ -182,13 +182,12 @@ def test_agencies_post(test_data_creator_flask: TestDataCreatorFlask):
         key_value_pairs={
             "state_iso": "PA",
             "county_name": "Allegheny",
-            "locality_name": data_to_post["location_info"]["locality_name"],
             **data_to_post["agency_info"],
         },
     )
 
     # Test with a new locality
-    data_to_post = get_sample_agency_post_parameters(
+    data_to_post = test_data_creator_flask.get_sample_agency_post_parameters(
         name=get_test_name(),
         jurisdiction_type=JurisdictionType.LOCAL,
         locality_name="Capitola",
@@ -205,7 +204,6 @@ def test_agencies_post(test_data_creator_flask: TestDataCreatorFlask):
             "name": data_to_post["agency_info"]["name"],
             "state_iso": "PA",
             "county_name": "Allegheny",
-            "locality_name": data_to_post["location_info"]["locality_name"],
         },
     )
 

--- a/tests/integration/test_data_requests.py
+++ b/tests/integration/test_data_requests.py
@@ -170,21 +170,8 @@ def test_data_requests_post(
 
     submission_notes = uuid.uuid4().hex
 
-    tdc.locality(locality_name="Laguna Hills")
-    tdc.locality(locality_name="Seal Beach")
-
-    location_info_1 = {
-        "type": "Locality",
-        "state_name": "Pennsylvania",
-        "county_name": "Allegheny",
-        "locality_name": "Laguna Hills",
-    }
-    location_info_2 = {
-        "type": "Locality",
-        "state_name": "Pennsylvania",
-        "county_name": "Allegheny",
-        "locality_name": "Seal Beach",
-    }
+    location_id_1 = tdc.locality(locality_name="Laguna Hills")
+    location_id_2 = tdc.locality(locality_name="Seal Beach")
 
     json_request = {
         "request_info": {
@@ -194,7 +181,7 @@ def test_data_requests_post(
             "request_urgency": RequestUrgency.URGENT.value,
             "coverage_range": "2000-2005",
         },
-        "location_infos": [location_info_1, location_info_2],
+        "location_ids": [location_id_1, location_id_2],
     }
 
     json_data = post_data_request(json_request)
@@ -208,9 +195,9 @@ def test_data_requests_post(
     locations = data["locations"]
     assert len(locations) == 2
     for location in locations:
-        if location["locality_name"] == location_info_1["locality_name"]:
+        if location["locality_name"] == "Laguna Hills":
             continue
-        if location["locality_name"] == location_info_2["locality_name"]:
+        if location["locality_name"] == "Seal Beach":
             continue
         assert False
 

--- a/tests/resources/test_DataRequests.py
+++ b/tests/resources/test_DataRequests.py
@@ -74,7 +74,7 @@ def test_data_requests_post_dto_population(
         ANY,
         dto=DataRequestsPostDTO(
             request_info=expected_request_info_dto,
-            location_infos=expected_locations_info_dto,
+            location_ids=expected_locations_info_dto,
         ),
         access_info=ANY,
     )

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -84,12 +84,7 @@ def test_agencies_post_schema():
             }
         }
         if include_location_info:
-            data["location_info"] = {
-                "type": "Locality",
-                "state_iso": "CA",
-                "county_fips": "06001",
-                "locality_name": "Los Angeles",
-            }
+            data["location_id"] = 1
         return data
 
     for jurisdiction_type in JurisdictionType:


### PR DESCRIPTION
### Fixes

* https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/563

### Description

* Replace requirement to provide extended location info to select endpoints with requiring only the provision of an associated location_id

### Testing

* Run tests to confirm expected functionality.

### Performance

* Should see slight performance improvement due to absence of logic necessitating pulling up a location.

### Docs

* Accompanying docs PRs, if applicable

### Breaking Changes

* `/agencies`, `/data-requests`, `POST` now no longer accept `location_info` inputs -- these have been replaced with `location_id`
* This will impact the admin retool interface, but nothing else.
