### PR TITLE
feat(database): add `table_log` table

### DIFF
--- a/alembic/versions/2025_02_17_1042-6097f5bfaecd_create_change_log_table_and_associated_.py
+++ b/alembic/versions/2025_02_17_1042-6097f5bfaecd_create_change_log_table_and_associated_.py
@@ -1,0 +1,136 @@
+"""Create change_log table and associated logic
+
+Revision ID: 6097f5bfaecd
+Revises: 9b4fc9265406
+Create Date: 2025-02-17 10:42:59.235505
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+# revision identifiers, used by Alembic.
+revision: str = "6097f5bfaecd"
+down_revision: Union[str, None] = "9b4fc9265406"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+OperationTypeEnum = sa.Enum("UPDATE", "DELETE", name="operation_type")
+
+
+def upgrade() -> None:
+    # Create change_log table
+    op.create_table(
+        "change_log",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("operation_type", OperationTypeEnum, nullable=False),
+        sa.Column("table_name", sa.String(), nullable=False),
+        sa.Column("affected_id", sa.Integer(), nullable=False),
+        sa.Column("old_data", JSONB, nullable=False),
+        sa.Column("new_data", JSONB, nullable=True),
+        sa.Column(
+            "created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.CheckConstraint(
+            "(operation_type = 'UPDATE' AND old_data IS NOT NULL AND new_data IS NOT NULL) OR "
+            "(operation_type = 'DELETE' AND old_data IS NOT NULL AND new_data IS NULL)",
+            name="check_update_data_not_null",
+        ),
+    )
+    # create jsonb_diff_val function
+    op.execute(
+        """
+    CREATE OR REPLACE FUNCTION jsonb_diff_val(val1 JSONB,val2 JSONB)
+        RETURNS JSONB AS $$
+        DECLARE
+          result JSONB;
+          v RECORD;
+        BEGIN
+           result = val1;
+           FOR v IN SELECT * FROM jsonb_each(val2) LOOP
+             IF result @> jsonb_build_object(v.key,v.value)
+                THEN result = result - v.key;
+             ELSIF result ? v.key THEN CONTINUE;
+             ELSE
+                result = result || jsonb_build_object(v.key,'null');
+             END IF;
+           END LOOP;
+           RETURN result;
+        END;
+        $$ LANGUAGE plpgsql;
+    """
+    )
+
+    # Create log_table_changes trigger function
+    op.execute(
+        """
+    CREATE OR REPLACE FUNCTION log_table_changes()
+        RETURNS TRIGGER AS $$
+        DECLARE
+            old_values JSONB;
+            new_values JSONB;
+            old_to_new JSONB;
+            new_to_old JSONB;
+        BEGIN
+            -- Identify the changed columns
+            old_values = row_to_json(OLD)::jsonb;
+        
+            -- Handle DELETE operations (store entire OLD row since all data is lost)
+            IF (TG_OP = 'DELETE') THEN
+                INSERT INTO change_log (operation_type, table_name, affected_id, old_data)
+                VALUES ('DELETE', TG_TABLE_NAME, OLD.id, old_values);
+                RETURN OLD;
+            
+            -- Handle UPDATE operations (only log the changed columns)
+            ELSIF (TG_OP = 'UPDATE') THEN
+                new_values = row_to_json(NEW)::jsonb;
+                new_to_old = jsonb_diff_val(old_values, new_values);
+                old_to_new = jsonb_diff_val(new_values, old_values);
+            
+                INSERT INTO change_log (operation_type, table_name, affected_id, old_data, new_data)
+                VALUES ('UPDATE', TG_TABLE_NAME, OLD.id, new_to_old, old_to_new);
+                RETURN NEW;
+            END IF;
+        END;
+        $$ LANGUAGE plpgsql;
+    """
+    )
+
+    # Create trigger for tables:
+    def create_trigger_query(table_name: str) -> str:
+        query = f"""
+        CREATE TRIGGER log_{table_name}_changes
+        BEFORE UPDATE OR DELETE ON {table_name}
+        FOR EACH ROW EXECUTE PROCEDURE log_table_changes();
+        """
+        op.execute(query)
+
+    # Agencies
+    create_trigger_query("agencies")
+    # Locations
+    create_trigger_query("locations")
+    # Localities
+    create_trigger_query("localities")
+    # Counties
+    create_trigger_query("counties")
+
+
+def downgrade() -> None:
+    # Drop log_location_changes trigger function
+    op.execute("DROP TRIGGER IF EXISTS log_locations_changes ON public.locations")
+    op.execute("DROP TRIGGER IF EXISTS log_agencies_changes ON public.agencies")
+    op.execute("DROP TRIGGER IF EXISTS log_localities_changes ON public.localities")
+    op.execute("DROP TRIGGER IF EXISTS log_counties_changes ON public.counties")
+    # Drop log_table_changes trigger function
+    op.execute("DROP FUNCTION IF EXISTS log_table_changes()")
+    # Drop jsonb_diff_val function
+    op.execute("DROP FUNCTION IF EXISTS jsonb_diff_val()")
+    # Drop change_log table
+    op.drop_table("change_log")
+    # Drop operation type enum
+    OperationTypeEnum.drop(op.get_bind())

--- a/database_client/database_client.py
+++ b/database_client/database_client.py
@@ -125,6 +125,7 @@ class DatabaseClient:
             self.session = self.session_maker()
             try:
                 result = method(self, *args, **kwargs)
+                self.session.flush()
                 self.session.commit()
                 return result
             except Exception as e:
@@ -866,6 +867,9 @@ class DatabaseClient:
     )
 
     def create_county(self, name: str, fips: str, state_id: int) -> int:
+        """
+        Create county and return county id
+        """
         return self._create_entry_in_table(
             table_name=Relations.COUNTIES.value,
             column_value_mappings={"name": name, "fips": fips, "state_id": state_id},
@@ -884,6 +888,7 @@ class DatabaseClient:
         subquery_parameters: Optional[list[SubqueryParameters]] = [],
         build_metadata: Optional[bool] = False,
         alias_mappings: Optional[dict[str, str]] = None,
+        apply_uniqueness_constraints: Optional[bool] = True,
     ) -> list[dict]:
         """
         Selects a single relation from the database
@@ -906,7 +911,10 @@ class DatabaseClient:
             subquery_parameters,
             alias_mappings,
         )
-        raw_results = self.session.execute(query()).mappings().unique().all()
+        if apply_uniqueness_constraints:
+            raw_results = self.session.execute(query()).mappings().unique().all()
+        else:
+            raw_results = self.session.execute(query()).mappings().all()
         results = self._process_results(
             build_metadata=build_metadata,
             raw_results=raw_results,
@@ -1520,6 +1528,22 @@ class DatabaseClient:
             updated_at=result["updated_at"],
         )
 
+    def get_change_logs_for_table(self, table: Relations):
+        return self._select_from_relation(
+            relation_name=Relations.CHANGE_LOG.value,
+            columns=[
+                "id",
+                "operation_type",
+                "table_name",
+                "affected_id",
+                "old_data",
+                "new_data",
+                "created_at",
+            ],
+            where_mappings={"table_name": table.value},
+            apply_uniqueness_constraints=False,
+        )
+
     @session_manager
     def get_users(self, page: int) -> List[UsersWithPermissions]:
         raw_results = self.session.execute(
@@ -1601,6 +1625,13 @@ class DatabaseClient:
             id_column_value=email,
             id_column_name="email",
         )
+
+    def get_locality_id_by_location_id(self, location_id: int):
+        return self._select_single_entry_from_relation(
+            relation_name=Relations.LOCATIONS_EXPANDED.value,
+            columns=["locality_id"],
+            where_mappings={"id": location_id},
+        )["locality_id"]
 
     def get_location_by_id(self, location_id: int):
         return self._select_single_entry_from_relation(

--- a/middleware/enums.py
+++ b/middleware/enums.py
@@ -89,6 +89,16 @@ class Relations(Enum):
     PERMISSIONS = "permissions"
     USER_PERMISSIONS = "user_permissions"
     TABLE_COUNT_LOG = "table_count_log"
+    CHANGE_LOG = "change_log"
+
+
+class OperationType(Enum):
+    """
+    A list of valid change log operation types
+    """
+
+    UPDATE = "UPDATE"
+    DELETE = "DELETE"
 
 
 class JurisdictionType(Enum):


### PR DESCRIPTION
### Fixes

* https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/621

### Description

* Create `table_log` table, which records updates and deletes of select tables. Currently only:
- agencies
- localities
- locations
- counties

### Testing

* Run tests to confirm all pass as expected

### Performance

* Increased performance overhead on updates and inserts to the above table
* Increase in test overhead

### Docs

* No documentation changes

### Breaking Changes

* No breaking changes. 