### PR TITLE
Mc 616 add unique constraint for county name state

### DIFF
--- a/alembic/versions/2025_02_15_1606-0d1f14861bb6_add_unique_constraint_for_county_name_.py
+++ b/alembic/versions/2025_02_15_1606-0d1f14861bb6_add_unique_constraint_for_county_name_.py
@@ -1,0 +1,36 @@
+"""Add unique constraint for county name and state
+
+Revision ID: 0d1f14861bb6
+Revises: 9b4fc9265406
+Create Date: 2025-02-15 16:06:46.492507
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "0d1f14861bb6"
+down_revision: Union[str, None] = "9b4fc9265406"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_unique_constraint(
+        "unique_county_name_and_state", "counties", ["name", "state_id"]
+    )
+    op.drop_column(table_name="counties", column_name="state_iso")
+
+
+def downgrade() -> None:
+    op.add_column(
+        table_name="counties",
+        column=sa.Column(
+            "state_iso", sa.VARCHAR(length=2), autoincrement=False, nullable=True
+        ),
+    )
+    op.drop_constraint("unique_county_name_and_state", "counties", type_="unique")

--- a/alembic/versions/2025_02_15_1606-0d1f14861bb6_add_unique_constraint_for_county_name_.py
+++ b/alembic/versions/2025_02_15_1606-0d1f14861bb6_add_unique_constraint_for_county_name_.py
@@ -1,7 +1,7 @@
 """Add unique constraint for county name and state
 
 Revision ID: 0d1f14861bb6
-Revises: 9b4fc9265406
+Revises: 2fbf7e4d2ccf
 Create Date: 2025-02-15 16:06:46.492507
 
 """
@@ -14,7 +14,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision: str = "0d1f14861bb6"
-down_revision: Union[str, None] = "9b4fc9265406"
+down_revision: Union[str, None] = "2fbf7e4d2ccf"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/database_client/database_client.py
+++ b/database_client/database_client.py
@@ -1196,6 +1196,16 @@ class DatabaseClient:
 
         return [row["column_name"] for row in results]
 
+    def get_county_id(self, county_name: str, state_id: int) -> int:
+        return self._select_single_entry_from_relation(
+            relation_name=Relations.COUNTIES.value,
+            columns=["id"],
+            where_mappings=[
+                WhereMapping(column="name", value=county_name),
+                WhereMapping(column="state_id", value=state_id),
+            ],
+        )
+
     def create_or_get(
         self,
         table_name: str,

--- a/tests/helper_scripts/helper_classes/TestDataCreatorDBClient.py
+++ b/tests/helper_scripts/helper_classes/TestDataCreatorDBClient.py
@@ -150,9 +150,14 @@ class TestDataCreatorDBClient:
         state_id = self.helper.get_state_id(state_iso=state_iso)
         if fips is None:
             fips = str(get_random_number_for_testing())
-        return self.db_client.create_county(
-            name=county_name, fips=fips, state_id=state_id
-        )
+        try:
+            return self.db_client.create_county(
+                name=county_name, fips=fips, state_id=state_id
+            )
+        except IntegrityError:
+            return self.db_client.get_county_id(
+                county_name=county_name, state_id=state_id
+            )
 
     def locality(
         self,

--- a/tests/helper_scripts/helper_functions_complex.py
+++ b/tests/helper_scripts/helper_functions_complex.py
@@ -104,7 +104,6 @@ def setup_get_typeahead_suggestion_test_data(cursor: Optional[psycopg.Cursor] = 
             column_value_mappings={
                 "fips": "12345",
                 "name": "Arxylodon",
-                "state_iso": "XY",
                 "state_id": state_id,
             },
             column_to_return="id",

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1021,7 +1021,7 @@ def test_counties_table_log_logic(test_data_creator_db_client: TestDataCreatorDB
     log = logs[1]
     assert log["operation_type"] == OperationType.DELETE.value
     assert log["affected_id"] == county_id
-    assert len(list(log["old_data"].keys())) == 12
+    assert len(list(log["old_data"].keys())) == 11
     assert log["new_data"] is None
 
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -5,14 +5,11 @@ which test the database-external views and functions
 """
 
 import uuid
-import zoneinfo
 from collections import namedtuple
 from datetime import datetime, timedelta, timezone
-from time import sleep
 
 import pytest
 from psycopg import sql
-from sqlalchemy.exc import IntegrityError
 
 from database_client.database_client import DatabaseClient
 from database_client.db_client_dataclasses import WhereMapping
@@ -30,7 +27,10 @@ from utilities.enums import RecordCategories
 
 ID_COLUMN = "state_iso"
 FAKE_STATE_INFO = {"state_iso": "ZZ", "state_name": "Zaldoniza"}
-FAKE_COUNTY_INFO = {"fips": "54321", "name": "Zipzapzibbidybop", "state_iso": "ZZ"}
+FAKE_COUNTY_INFO = {
+    "fips": "54321",
+    "name": "Zipzapzibbidybop",
+}
 FAKE_LOCALITY_INFO = {"name": "Zoolazoolio"}
 
 FakeLocationsInfo = namedtuple(


### PR DESCRIPTION
### Fixes

* https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/616

### Description

* Add unique constraint for counties, ensuring that two counties cannot have the same name and state.
* Additionally removes redundant `state_iso` column from `counties`

### Testing

* Run tests and confirm all pass as expected.

### Performance

* Impact marginal

### Docs

* No documentation changes

### Breaking Changes

* No breaking changes.