### PR TITLE
fix(db_client): fix bug in `get_metrics`

### DIFF
--- a/database_client/database_client.py
+++ b/database_client/database_client.py
@@ -1725,10 +1725,10 @@ class DatabaseClient:
                 DATA_SOURCES
             UNION
             SELECT
-                COUNT(DISTINCT (ID)),
+                COUNT(DISTINCT (AGENCY_ID)),
                 'agency_count' "Count Type"
             FROM
-                AGENCIES
+                link_agencies_data_sources
             UNION
             SELECT
                 COUNT(DISTINCT L.ID),


### PR DESCRIPTION
`agency_count` now determined by number of agencies that have data sources, rather than number of agencies overall.

Fixes bug that I thought was a fix in https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/615