### PR TITLE
feat(database): enhance typeahead_locations display_name

### DIFF
--- a/alembic/versions/2025_02_20_1503-2f5d03d58839_enhance_display_name_for_typeahead_.py
+++ b/alembic/versions/2025_02_20_1503-2f5d03d58839_enhance_display_name_for_typeahead_.py
@@ -1,0 +1,76 @@
+"""Enhance display name for typeahead locations materialized view
+
+Revision ID: 2f5d03d58839
+Revises: 0d1f14861bb6
+Create Date: 2025-02-20 15:03:32.900346
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "2f5d03d58839"
+down_revision: Union[str, None] = "0d1f14861bb6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Drop old materialized view
+    op.execute("DROP MATERIALIZED VIEW IF EXISTS public.typeahead_locations")
+
+    # Create new materialized view
+    op.execute(
+        """
+        CREATE MATERIALIZED VIEW IF NOT EXISTS public.typeahead_locations as
+         SELECT le.id AS location_id,
+            CASE
+                WHEN le.type = 'Locality'::location_type THEN le.locality_name
+                WHEN le.type = 'County'::location_type THEN le.county_name::character varying
+                WHEN le.type = 'State'::location_type THEN le.state_name::character varying
+                ELSE NULL::character varying
+            END AS search_name,
+            CASE
+                WHEN le.type = 'Locality'::location_type THEN CONCAT(le.locality_name, ', ', le.county_name, ', ', le.state_name)
+                WHEN le.type = 'County'::location_type THEN CONCAT(le.county_name, ', ', le.state_name)
+                WHEN le.type = 'State'::location_type THEN le.state_name::character varying
+                ELSE NULL::character varying
+            END AS display_name,
+        le.type,
+        le.state_name,
+        le.county_name,
+        le.locality_name
+       FROM locations_expanded le
+    WITH DATA;
+    """
+    )
+
+
+def downgrade() -> None:
+    # Drop new materialized view
+    op.execute("DROP MATERIALIZED VIEW IF EXISTS public.typeahead_locations")
+
+    # Create old materialized view
+    op.execute(
+        """
+    CREATE MATERIALIZED VIEW IF NOT EXISTS public.typeahead_locations
+    AS
+     SELECT locations_expanded.id AS location_id,
+            CASE
+                WHEN locations_expanded.type = 'Locality'::location_type THEN locations_expanded.locality_name
+                WHEN locations_expanded.type = 'County'::location_type THEN locations_expanded.county_name::character varying
+                WHEN locations_expanded.type = 'State'::location_type THEN locations_expanded.state_name::character varying
+                ELSE NULL::character varying
+            END AS display_name,
+        locations_expanded.type,
+        locations_expanded.state_name,
+        locations_expanded.county_name,
+        locations_expanded.locality_name
+       FROM locations_expanded
+    WITH DATA;
+    """
+    )

--- a/database_client/dynamic_query_constructor.py
+++ b/database_client/dynamic_query_constructor.py
@@ -152,7 +152,7 @@ class DynamicQueryConstructor:
                 locality_name,
                 location_id
             FROM typeahead_locations
-            WHERE display_name ILIKE {search_term_prefix}
+            WHERE search_name ILIKE {search_term_prefix}
             UNION ALL
             SELECT
                 2 AS sort_order,
@@ -163,8 +163,8 @@ class DynamicQueryConstructor:
                 locality_name,
                 location_id
             FROM typeahead_locations
-            WHERE display_name ILIKE {search_term_anywhere}
-            AND display_name NOT ILIKE {search_term_prefix}
+            WHERE search_name ILIKE {search_term_anywhere}
+            AND search_name NOT ILIKE {search_term_prefix}
         )
         SELECT display_name, type, state_name, county_name, locality_name, location_id
         FROM (

--- a/tests/integration/test_typeahead_suggestions.py
+++ b/tests/integration/test_typeahead_suggestions.py
@@ -20,7 +20,7 @@ def test_typeahead_locations(flask_client_with_db):
     setup_get_typeahead_suggestion_test_data()
     expected_suggestions = [
         {
-            "display_name": "Xylodammerung",
+            "display_name": "Xylodammerung, Arxylodon, Xylonsylvania",
             "locality_name": "Xylodammerung",
             "county_name": "Arxylodon",
             "state_name": "Xylonsylvania",
@@ -34,7 +34,7 @@ def test_typeahead_locations(flask_client_with_db):
             "type": "State",
         },
         {
-            "display_name": "Arxylodon",
+            "display_name": "Arxylodon, Xylonsylvania",
             "locality_name": None,
             "county_name": "Arxylodon",
             "state_name": "Xylonsylvania",

--- a/tests/test_database_client.py
+++ b/tests/test_database_client.py
@@ -608,7 +608,7 @@ def test_get_typeahead_locations(live_database_client: DatabaseClient):
     # Check that the results are as expected
     assert len(results) == 3
 
-    assert results[0]["display_name"] == "Xylodammerung"
+    assert results[0]["display_name"] == "Xylodammerung, Arxylodon, Xylonsylvania"
     assert results[0]["type"] == "Locality"
     assert results[0]["state_name"] == "Xylonsylvania"
     assert results[0]["county_name"] == "Arxylodon"
@@ -620,7 +620,7 @@ def test_get_typeahead_locations(live_database_client: DatabaseClient):
     assert results[1]["county_name"] is None
     assert results[1]["locality_name"] is None
 
-    assert results[2]["display_name"] == "Arxylodon"
+    assert results[2]["display_name"] == "Arxylodon, Xylonsylvania"
     assert results[2]["type"] == "County"
     assert results[2]["state_name"] == "Xylonsylvania"
     assert results[2]["county_name"] == "Arxylodon"


### PR DESCRIPTION
### Fixes

* Supports https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/619

### Description

Enhance `typeahead_locations` display_name to now show 
* `Locality, County, State` (for localities)
* `County, State` (for counties)

### Testing

* Run tests to confirm functionality.

### Performance

* Impact marginal

### Docs

* Accompanying docs PRs, if applicable

### Breaking Changes

* This impacts the `/typeahead/locations` endpoint -- the client app will need modified.