### PR TITLE
feat(api): add `record_types` option to `/search/search-location-and-record-type`

### DIFF
--- a/alembic/versions/2025_02_25_1310-da63f84a9f34_create_linkrecentsearchrecordtypes_table.py
+++ b/alembic/versions/2025_02_25_1310-da63f84a9f34_create_linkrecentsearchrecordtypes_table.py
@@ -1,0 +1,40 @@
+"""Create LinkRecentSearchRecordTypes table
+
+Revision ID: da63f84a9f34
+Revises: 2f5d03d58839
+Create Date: 2025-02-25 13:10:36.133597
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "da63f84a9f34"
+down_revision: Union[str, None] = "2f5d03d58839"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "link_recent_search_record_types",
+        sa.Column("id", sa.Integer, primary_key=True),
+        # Recent search ID, foreign key to recent_searches
+        sa.Column("recent_search_id", sa.Integer, nullable=False),
+        # Record type ID, foreign key to record_types
+        sa.Column("record_type_id", sa.Integer, nullable=False),
+        sa.ForeignKeyConstraint(
+            ["recent_search_id"], ["recent_searches.id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(
+            ["record_type_id"], ["record_types.id"], ondelete="CASCADE"
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("link_recent_search_record_types")

--- a/database_client/dynamic_query_constructor.py
+++ b/database_client/dynamic_query_constructor.py
@@ -22,6 +22,7 @@ from database_client.models import (
     SQL_ALCHEMY_TABLE_REFERENCE,
     convert_to_column_reference,
 )
+from middleware.enums import RecordTypes
 from utilities.enums import RecordCategories
 
 TableColumn = namedtuple("TableColumn", ["table", "column"])
@@ -314,6 +315,7 @@ class DynamicQueryConstructor:
     def create_search_query(
         location_id: int,
         record_categories: Optional[list[RecordCategories]] = None,
+        record_types: Optional[list[RecordTypes]] = None,
     ) -> sql.Composed:
 
         base_query = sql.SQL(
@@ -373,6 +375,15 @@ class DynamicQueryConstructor:
             ]
             where_subclauses.append(
                 sql.SQL("record_categories.name = ANY({record_types})").format(
+                    record_types=sql.Literal(record_type_str_list)
+                )
+            )
+
+        if record_types is not None:
+
+            record_type_str_list = [[record_type.value for record_type in record_types]]
+            where_subclauses.append(
+                sql.SQL("record_types.name = ANY({record_types})").format(
                     record_types=sql.Literal(record_type_str_list)
                 )
             )

--- a/database_client/models.py
+++ b/database_client/models.py
@@ -757,6 +757,16 @@ class LinkRecentSearchRecordCategories(Base):
     )
 
 
+class LinkRecentSearchRecordTypes(Base):
+    __tablename__ = Relations.LINK_RECENT_SEARCH_RECORD_TYPES.value
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    recent_search_id: Mapped[int] = mapped_column(
+        ForeignKey("public.recent_searches.id")
+    )
+    record_type_id: Mapped[int] = mapped_column(ForeignKey("public.record_types.id"))
+
+
 # TODO: Change user_id references in models to be from singular factory function or constant, to avoid duplication
 # Do the same for other common foreign keys, or for things such as primary keys
 
@@ -816,6 +826,7 @@ SQL_ALCHEMY_TABLE_REFERENCE = {
     Relations.USER_NOTIFICATION_QUEUE.value: UserNotificationQueue,
     Relations.RECENT_SEARCHES.value: RecentSearch,
     Relations.LINK_RECENT_SEARCH_RECORD_CATEGORIES.value: LinkRecentSearchRecordCategories,
+    Relations.LINK_RECENT_SEARCH_RECORD_TYPES.value: LinkRecentSearchRecordTypes,
     Relations.RECORD_CATEGORIES.value: RecordCategory,
     Relations.RECENT_SEARCHES_EXPANDED.value: RecentSearchExpanded,
     Relations.RECORD_TYPES.value: RecordType,

--- a/middleware/enums.py
+++ b/middleware/enums.py
@@ -86,6 +86,7 @@ class Relations(Enum):
     RECENT_SEARCHES = "recent_searches"
     RECENT_SEARCHES_EXPANDED = "recent_searches_expanded"
     LINK_RECENT_SEARCH_RECORD_CATEGORIES = "link_recent_search_record_categories"
+    LINK_RECENT_SEARCH_RECORD_TYPES = "link_recent_search_record_types"
     PERMISSIONS = "permissions"
     USER_PERMISSIONS = "user_permissions"
     TABLE_COUNT_LOG = "table_count_log"
@@ -139,7 +140,7 @@ class AgencyType(Enum):
     UNKNOWN = "unknown"
 
 
-class RecordType(Enum):
+class RecordTypes(Enum):
     ACCIDENT_REPORTS = "Accident Reports"
     ARREST_RECORDS = "Arrest Records"
     CALLS_FOR_SERVICE = "Calls for Service"

--- a/middleware/primary_resource_logic/search_logic.py
+++ b/middleware/primary_resource_logic/search_logic.py
@@ -108,6 +108,7 @@ def search_wrapper(
     search_results = db_client.search_with_location_and_record_type(
         location_id=dto.location_id,
         record_categories=explicit_record_categories,
+        record_types=dto.record_types,
         # Pass modified record categories, which breaks down ALL into individual categories
     )
     return send_search_results(
@@ -140,6 +141,7 @@ def create_search_record(access_info, db_client, dto):
         location_id=dto.location_id,
         # Pass originally provided record categories
         record_categories=dto.record_categories,
+        record_types=dto.record_types,
     )
 
 
@@ -169,8 +171,10 @@ def send_as_csv(search_results):
 
 
 def get_explicit_record_categories(
-    record_categories=list[RecordCategories],
-) -> list[RecordCategories]:
+    record_categories=Optional[list[RecordCategories]],
+) -> Optional[list[RecordCategories]]:
+    if record_categories is None:
+        return None
     if RecordCategories.ALL in record_categories:
         if len(record_categories) > 1:
             FlaskResponseManager.abort(

--- a/middleware/schema_and_dto_logic/primary_resource_dtos/data_requests_dtos.py
+++ b/middleware/schema_and_dto_logic/primary_resource_dtos/data_requests_dtos.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel
 
 from database_client.db_client_dataclasses import WhereMapping
 from database_client.enums import LocationType, RequestStatus, RequestUrgency
-from middleware.enums import RecordType
+from middleware.enums import RecordTypes
 from middleware.schema_and_dto_logic.common_schemas_and_dtos import (
     GetManyBaseDTO,
     GetByIDBaseDTO,
@@ -44,7 +44,7 @@ class DataRequestsPutDTO(BaseModel):
     github_issue_url: Optional[str] = None
     github_issue_number: Optional[int] = None
     internal_notes: Optional[str] = None
-    record_types_required: Optional[list[RecordType]] = None
+    record_types_required: Optional[list[RecordTypes]] = None
     pdap_response: Optional[str] = None
 
 

--- a/middleware/schema_and_dto_logic/primary_resource_dtos/data_sources_dtos.py
+++ b/middleware/schema_and_dto_logic/primary_resource_dtos/data_sources_dtos.py
@@ -13,7 +13,7 @@ from database_client.enums import (
     URLStatus,
     UpdateMethod,
 )
-from middleware.enums import RecordType
+from middleware.enums import RecordTypes
 
 
 class DataSourceEntryDataPostDTO(BaseModel):
@@ -48,7 +48,7 @@ class DataSourceEntryDataPostDTO(BaseModel):
     broken_source_url_as_of: Optional[date] = None
     access_notes: Optional[str] = None
     url_status: Optional[URLStatus] = None
-    record_type_name: Optional[RecordType] = None
+    record_type_name: Optional[RecordTypes] = None
 
 
 class DataSourceEntryDataPutDTO(BaseModel):
@@ -79,7 +79,7 @@ class DataSourceEntryDataPutDTO(BaseModel):
     data_portal_type_other: Optional[str] = None
     access_notes: Optional[str] = None
     url_status: Optional[URLStatus] = None
-    record_type_name: Optional[RecordType] = None
+    record_type_name: Optional[RecordTypes] = None
 
 
 class DataSourcesPutDTO(BaseModel):

--- a/middleware/schema_and_dto_logic/primary_resource_schemas/data_requests_base_schema.py
+++ b/middleware/schema_and_dto_logic/primary_resource_schemas/data_requests_base_schema.py
@@ -1,7 +1,7 @@
 from marshmallow import Schema, fields
 
 from database_client.enums import RequestStatus, RequestUrgency
-from middleware.enums import RecordType
+from middleware.enums import RecordTypes
 from middleware.schema_and_dto_logic.util import get_json_metadata
 
 
@@ -69,7 +69,7 @@ class DataRequestsSchema(Schema):
     )
     record_types_required = fields.List(
         fields.Enum(
-            enum=RecordType,
+            enum=RecordTypes,
             by_value=fields.Str,
             metadata=get_json_metadata(
                 "The record types associated with the data request. Editable only by admins."

--- a/middleware/schema_and_dto_logic/primary_resource_schemas/data_requests_schemas.py
+++ b/middleware/schema_and_dto_logic/primary_resource_schemas/data_requests_schemas.py
@@ -1,7 +1,7 @@
 from marshmallow import fields, Schema, post_load
 
 from database_client.enums import RequestStatus, RequestUrgency
-from middleware.enums import RecordType
+from middleware.enums import RecordTypes
 from middleware.primary_resource_logic.data_requests import RequestInfoPostDTO
 from middleware.schema_and_dto_logic.primary_resource_schemas.typeahead_suggestion_schemas import (
     TypeaheadLocationsResponseSchema,
@@ -94,7 +94,7 @@ class DataRequestsSchema(Schema):
     )
     record_types_required = fields.List(
         fields.Enum(
-            enum=RecordType,
+            enum=RecordTypes,
             by_value=fields.Str,
             metadata=get_json_metadata(
                 "The record types associated with the data request. Editable only by admins."

--- a/middleware/schema_and_dto_logic/primary_resource_schemas/data_sources_base_schemas.py
+++ b/middleware/schema_and_dto_logic/primary_resource_schemas/data_sources_base_schemas.py
@@ -9,7 +9,7 @@ from database_client.enums import (
     URLStatus,
     ApprovalStatus,
 )
-from middleware.enums import RecordType
+from middleware.enums import RecordTypes
 from middleware.schema_and_dto_logic.enums import CSVColumnCondition
 from middleware.schema_and_dto_logic.util import get_json_metadata
 
@@ -304,7 +304,7 @@ class DataSourceBaseSchema(Schema):
 
 class DataSourceExpandedSchema(DataSourceBaseSchema):
     record_type_name = fields.Enum(
-        enum=RecordType,
+        enum=RecordTypes,
         by_value=fields.Str,
         allow_none=True,
         metadata=get_json_metadata(

--- a/tests/alembic/test_alembic_migrations.py
+++ b/tests/alembic/test_alembic_migrations.py
@@ -80,3 +80,8 @@ def test_add_user_create_update_permissions(alembic_runner: AlembicRunner):
         """
     )
     assert len(results) == 1
+
+
+def test_revision_upgrade_downgrade(alembic_runner: AlembicRunner):
+    alembic_runner.upgrade("head")
+    alembic_runner.downgrade("base")

--- a/tests/integration/test_data_requests.py
+++ b/tests/integration/test_data_requests.py
@@ -8,7 +8,7 @@ from flask.testing import FlaskClient
 from database_client.db_client_dataclasses import WhereMapping
 from database_client.enums import RequestUrgency, LocationType, RequestStatus, SortOrder
 from middleware.constants import DATA_KEY
-from middleware.enums import RecordType
+from middleware.enums import RecordTypes
 from middleware.util import get_enum_values
 from resources.endpoint_schema_config import SchemaConfigs
 from tests.helper_scripts.common_test_data import (
@@ -357,7 +357,7 @@ def test_data_requests_by_id_put(
                 "github_issue_url": uuid.uuid4().hex,
                 "github_issue_number": get_random_number_for_testing(),
                 "pdap_response": uuid.uuid4().hex,
-                "record_types_required": get_enum_values(RecordType),
+                "record_types_required": get_enum_values(RecordTypes),
             }
         },
     )

--- a/tests/integration/test_data_sources.py
+++ b/tests/integration/test_data_sources.py
@@ -15,7 +15,7 @@ from database_client.enums import (
     UpdateMethod,
     SortOrder,
 )
-from middleware.enums import RecordType
+from middleware.enums import RecordTypes
 from middleware.schema_and_dto_logic.primary_resource_schemas.data_sources_base_schemas import (
     DataSourceExpandedSchema,
 )
@@ -248,7 +248,7 @@ def test_data_sources_by_id_put(test_data_creator_flask: TestDataCreatorFlask):
         "data_portal_type_other": uuid.uuid4().hex,
         "access_notes": uuid.uuid4().hex,
         "url_status": URLStatus.OK.value,
-        "record_type_name": RecordType.ARREST_RECORDS.value,
+        "record_type_name": RecordTypes.ARREST_RECORDS.value,
     }
 
     run_and_validate_request(

--- a/tests/integration/test_search.py
+++ b/tests/integration/test_search.py
@@ -12,7 +12,10 @@ from middleware.enums import (
     JurisdictionSimplified,
     JurisdictionType,
     AgencyType,
+    RecordTypes,
+    Relations,
 )
+from middleware.schema_and_dto_logic.common_response_schemas import MessageSchema
 from middleware.schema_and_dto_logic.primary_resource_schemas.agencies_advanced_schemas import (
     AgencyInfoPostSchema,
 )
@@ -35,6 +38,7 @@ from tests.helper_scripts.run_and_validate_request import (
     http_methods,
 )
 from conftest import test_data_creator_flask, monkeysession
+from tests.integration.test_check_database_health import wipe_database
 from utilities.enums import RecordCategories
 
 ENDPOINT_SEARCH_LOCATION_AND_RECORD_TYPE = "/search/search-location-and-record-type"
@@ -55,6 +59,8 @@ class SearchTestSetup:
 @pytest.fixture
 def search_test_setup(test_data_creator_flask: TestDataCreatorFlask):
     tdc = test_data_creator_flask
+    wipe_database(tdc.db_client)
+
     try:
         tdc.locality(TEST_LOCALITY)
     except Exception:
@@ -184,6 +190,96 @@ def test_search_get_record_categories_all(
     data_empty = run_search(record_categories=[])
     assert data_empty["count"] > 0
     assert data_empty["count"] == data_all_explicit["count"]
+
+
+def test_search_get_record_type_singular(search_test_setup: SearchTestSetup):
+    """
+    The `record_type` parameter should be able to be provided as a singular value
+    """
+    sts = search_test_setup
+    tdc = sts.tdc
+    tus = sts.tus
+
+    tdcdb = tdc.tdcdb
+
+    for i in range(2):
+        tdcdb.link_data_source_to_agency(
+            data_source_id=tdcdb.data_source(record_type_id=i + 1).id,
+            agency_id=tdcdb.agency(location_id=sts.location_id).id,
+        )
+
+    results = tdc.request_validator.search(
+        headers=tus.api_authorization_header,
+        location_id=sts.location_id,
+        record_types=[RecordTypes.ARREST_RECORDS],
+    )
+    assert results["count"] == 1
+    assert (
+        results["data"]["federal"]["results"][0]["record_type"]
+        == RecordTypes.ARREST_RECORDS.value
+    )
+
+    links = tdc.db_client._select_from_relation(
+        relation_name=Relations.LINK_RECENT_SEARCH_RECORD_TYPES.value,
+        columns=["record_type_id"],
+    )
+    assert len(links) == 1
+    assert {link["record_type_id"] for link in links} == {2}
+
+
+def test_search_get_record_type_multiple(search_test_setup: SearchTestSetup):
+    """
+    The `record_type` parameter should be able to be provided as a list of values
+    """
+    sts = search_test_setup
+    tdc = sts.tdc
+    tus = sts.tus
+
+    tdcdb = tdc.tdcdb
+
+    for i in range(3):
+        tdcdb.link_data_source_to_agency(
+            data_source_id=tdcdb.data_source(record_type_id=i + 1).id,
+            agency_id=tdcdb.agency(location_id=sts.location_id).id,
+        )
+
+    results = tdc.request_validator.search(
+        headers=tus.api_authorization_header,
+        location_id=sts.location_id,
+        record_types=[RecordTypes.ARREST_RECORDS, RecordTypes.ACCIDENT_REPORTS],
+    )
+    assert results["count"] == 2
+
+    links = tdc.db_client._select_from_relation(
+        relation_name=Relations.LINK_RECENT_SEARCH_RECORD_TYPES.value,
+        columns=["record_type_id"],
+    )
+    assert len(links) == 2
+    assert {link["record_type_id"] for link in links} == {1, 2}
+
+
+def test_search_get_record_type_not_with_record_category(
+    search_test_setup: SearchTestSetup,
+):
+    """
+    The `record_type` parameter should not be provided if `record_category` is provided.
+    If this occurs, an error should be returned
+    """
+    sts = search_test_setup
+    tdc = sts.tdc
+    tus = sts.tus
+
+    tdc.request_validator.search(
+        headers=tus.api_authorization_header,
+        location_id=sts.location_id,
+        record_categories=[RecordCategories.POLICE],
+        record_types=[RecordTypes.ARREST_RECORDS],
+        expected_response_status=HTTPStatus.BAD_REQUEST,
+        expected_schema=MessageSchema,
+        expected_json_content={
+            "message": "Only one of 'record_categories' or 'record_types' should be provided."
+        },
+    )
 
 
 def test_search_follow(search_test_setup: SearchTestSetup):

--- a/tests/test_database_client.py
+++ b/tests/test_database_client.py
@@ -36,7 +36,7 @@ from database_client.models import (
     User,
     SQL_ALCHEMY_TABLE_REFERENCE,
 )
-from middleware.enums import PermissionsEnum, Relations, RecordType
+from middleware.enums import PermissionsEnum, Relations, RecordTypes
 from tests.conftest import live_database_client, test_table_data, clear_data_requests
 from tests.helper_scripts.common_test_data import (
     get_random_number_for_testing,
@@ -692,7 +692,7 @@ def test_search_with_location_and_record_types_real_data(
     secondary_location_id = tdc.locality()
 
     def agency_and_data_source(
-        location_id, record_type: RecordType = RecordType.LIST_OF_DATA_SOURCES
+        location_id, record_type: RecordTypes = RecordTypes.LIST_OF_DATA_SOURCES
     ):
         record_type_id = live_database_client.get_record_type_id_by_name(
             record_type.value
@@ -706,7 +706,7 @@ def test_search_with_location_and_record_types_real_data(
     # State
     agency_and_data_source(pennsylvania_location_id)
     agency_and_data_source(
-        pennsylvania_location_id, record_type=RecordType.RECORDS_REQUEST_INFO
+        pennsylvania_location_id, record_type=RecordTypes.RECORDS_REQUEST_INFO
     )
     # Counties
     agency_and_data_source(allegheny_location_id)
@@ -715,7 +715,7 @@ def test_search_with_location_and_record_types_real_data(
     agency_and_data_source(pittsburgh_location_id)
     agency_and_data_source(secondary_location_id)
     agency_and_data_source(
-        pittsburgh_location_id, record_type=RecordType.RECORDS_REQUEST_INFO
+        pittsburgh_location_id, record_type=RecordTypes.RECORDS_REQUEST_INFO
     )
 
     def search(state, record_categories=None, county=None, locality=None):
@@ -779,7 +779,7 @@ def test_search_with_location_and_record_types_real_data_multiple_records(
     tdc = test_data_creator_db_client
 
     def agency_and_data_source(
-        location_id, record_type: RecordType = RecordType.LIST_OF_DATA_SOURCES
+        location_id, record_type: RecordTypes = RecordTypes.LIST_OF_DATA_SOURCES
     ):
         record_type_id = live_database_client.get_record_type_id_by_name(
             record_type.value
@@ -790,7 +790,7 @@ def test_search_with_location_and_record_types_real_data_multiple_records(
         a_id = tdc.agency(location_id=location_id).id
         tdc.link_data_source_to_agency(data_source_id=ds_id, agency_id=a_id)
 
-    record_types = [record_type for record_type in RecordType]
+    record_types = [record_type for record_type in RecordTypes]
     for record_type in record_types:
         agency_and_data_source(pa_location_id, record_type=record_type)
 


### PR DESCRIPTION
### Fixes

* https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/625

### Description

* Add `record_type` search endpoint to `/search/search-location-and-record-type`

### Testing

* Run tests and confirm functionality.

### Performance

* Slight increase in test overhead
* Slight increase in overhead for search functionality 

### Docs

* API documentation for `/search/search-location-and-record-type` updated

### Breaking Changes

* No breaking changes. 