### PR TITLE
feat(database): add `archive_write` permission

### DIFF
--- a/alembic/versions/2025_02_25_1826-4713a996cf91_create_archive_write_permission.py
+++ b/alembic/versions/2025_02_25_1826-4713a996cf91_create_archive_write_permission.py
@@ -1,0 +1,37 @@
+"""Create archive_write_permission
+
+Revision ID: 4713a996cf91
+Revises: da63f84a9f34
+Create Date: 2025-02-25 18:26:00.053199
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "4713a996cf91"
+down_revision: Union[str, None] = "da63f84a9f34"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+    INSERT INTO permissions 
+    (permission_name, description) VALUES 
+    ('archive_write', 'Enables archiving of data sources');
+    """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+    DELETE FROM permissions WHERE permission_name = 'archive_write';
+    """
+    )

--- a/middleware/access_logic.py
+++ b/middleware/access_logic.py
@@ -42,6 +42,10 @@ WRITE_ONLY_AUTH_INFO = AuthenticationInfo(
     allowed_access_methods=[AccessTypeEnum.JWT],
     restrict_to_permissions=[PermissionsEnum.DB_WRITE],
 )
+ARCHIVE_WRITE_AUTH_INFO = AuthenticationInfo(
+    allowed_access_methods=[AccessTypeEnum.JWT],
+    restrict_to_permissions=[PermissionsEnum.ARCHIVE_WRITE],
+)
 # Allow owners of a resource to use the endpoint as well, instead of only admin-level users
 STANDARD_JWT_AUTH_INFO = AuthenticationInfo(
     allowed_access_methods=[AccessTypeEnum.JWT],

--- a/middleware/enums.py
+++ b/middleware/enums.py
@@ -21,6 +21,7 @@ class PermissionsEnum(Enum):
     NOTIFICATIONS = "notifications"
     SOURCE_COLLECTOR = "source_collector"
     USER_CREATE_UPDATE = "user_create_update"
+    ARCHIVE_WRITE = "archive_write"
 
     @classmethod
     def values(cls):

--- a/resources/Archives.py
+++ b/resources/Archives.py
@@ -5,6 +5,7 @@ from middleware.access_logic import (
     API_OR_JWT_AUTH_INFO,
     AccessInfoPrimary,
     WRITE_ONLY_AUTH_INFO,
+    ARCHIVE_WRITE_AUTH_INFO,
 )
 from middleware.decorators import api_key_required, permissions_required, endpoint_info
 from middleware.primary_resource_logic.archives_queries import (
@@ -59,7 +60,7 @@ class Archives(PsycopgResource):
 
     @endpoint_info(
         namespace=namespace_archives,
-        auth_info=WRITE_ONLY_AUTH_INFO,
+        auth_info=ARCHIVE_WRITE_AUTH_INFO,
         schema_config=SchemaConfigs.ARCHIVES_PUT,
         response_info=ResponseInfo(
             success_message="Successfully updated the archive data.",

--- a/tests/helper_scripts/helper_functions_complex.py
+++ b/tests/helper_scripts/helper_functions_complex.py
@@ -180,6 +180,7 @@ def create_admin_test_user_setup(flask_client: FlaskClient) -> TestUserSetup:
             PermissionsEnum.READ_ALL_USER_INFO,
             PermissionsEnum.DB_WRITE,
             PermissionsEnum.USER_CREATE_UPDATE,
+            PermissionsEnum.ARCHIVE_WRITE,
         ],
     )
     return tus_admin


### PR DESCRIPTION
Supports https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/608

Add `archive_write` permission for `archives` endpoints that directly impact the database