### PR TITLE
feat(auth): revamp `/refresh-session` endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -127,7 +127,7 @@ def create_app() -> Flask:
     # JWT settings
     app.config["JWT_SECRET_KEY"] = os.getenv("JWT_SECRET_KEY")
     app.config["JWT_ACCESS_TOKEN_EXPIRES"] = timedelta(minutes=15)
-    app.config["JWT_REFRESH_TOKEN_EXPIRES"] = timedelta(days=30)
+    app.config["JWT_REFRESH_TOKEN_EXPIRES"] = timedelta(days=1)
 
     # Other configuration settings
     app.config["MAX_CONTENT_LENGTH"] = 16 * 1024 * 1024

--- a/middleware/SimpleJWT.py
+++ b/middleware/SimpleJWT.py
@@ -17,6 +17,7 @@ class JWTPurpose(Enum):
     VALIDATE_EMAIL = auto()
     GITHUB_ACCESS_TOKEN = auto()
     STANDARD_ACCESS_TOKEN = auto()
+    REFRESH_TOKEN = auto()
 
 
 def get_secret_key(purpose: JWTPurpose):

--- a/middleware/access_logic.py
+++ b/middleware/access_logic.py
@@ -332,8 +332,7 @@ def validate_refresh_token(token: str, **kwargs) -> Optional[RefreshAccessInfo]:
     decoded_refresh_token = decode_token(token)
     token_type: str = decoded_refresh_token["type"]
     # The below is flagged as a false positive through bandit security linting, misidentifying it as a password
-    # nosec
-    if token_type != "refresh":
+    if token_type != "refresh":  # nosec
         FlaskResponseManager.abort(
             code=HTTPStatus.BAD_REQUEST, message="Invalid refresh token"
         )

--- a/middleware/access_logic.py
+++ b/middleware/access_logic.py
@@ -331,6 +331,8 @@ def validate_email_handler(
 def validate_refresh_token(token: str, **kwargs) -> Optional[RefreshAccessInfo]:
     decoded_refresh_token = decode_token(token)
     token_type: str = decoded_refresh_token["type"]
+    # The below is flagged as a false positive through bandit security linting, misidentifying it as a password
+    # nosec
     if token_type != "refresh":
         FlaskResponseManager.abort(
             code=HTTPStatus.BAD_REQUEST, message="Invalid refresh token"

--- a/middleware/decorators.py
+++ b/middleware/decorators.py
@@ -28,6 +28,7 @@ from resources.resource_helpers import (
     create_response_dictionary,
     add_password_reset_token_header_arg,
     add_validate_email_header_arg,
+    add_refresh_jwt_header_arg,
 )
 from resources.endpoint_schema_config import SchemaConfigs, OutputSchemaManager
 
@@ -213,6 +214,7 @@ ACCESS_TYPE_HEADER_ARG_FUNC_MAP = {
     AccessTypeEnum.API_KEY: add_api_key_header_arg,
     AccessTypeEnum.RESET_PASSWORD: add_password_reset_token_header_arg,
     AccessTypeEnum.VALIDATE_EMAIL: add_validate_email_header_arg,
+    AccessTypeEnum.REFRESH_JWT: add_refresh_jwt_header_arg,
 }
 
 

--- a/middleware/enums.py
+++ b/middleware/enums.py
@@ -39,6 +39,7 @@ class PermissionsActionEnum(Enum):
 
 class AccessTypeEnum(Enum):
     JWT = auto()
+    REFRESH_JWT = auto()
     API_KEY = auto()
     RESET_PASSWORD = auto()
     VALIDATE_EMAIL = auto()

--- a/resources/endpoint_schema_config.py
+++ b/resources/endpoint_schema_config.py
@@ -499,9 +499,7 @@ class SchemaConfigs(Enum):
 
     # endregion
     REFRESH_SESSION = EndpointSchemaConfig(
-        input_schema=RefreshSessionRequestSchema(),
         primary_output_schema=LoginResponseSchema(),
-        input_dto_class=RefreshSessionRequestDTO,
     )
     # region Reset Password
     REQUEST_RESET_PASSWORD = schema_config_with_message_output(

--- a/resources/resource_helpers.py
+++ b/resources/resource_helpers.py
@@ -37,13 +37,23 @@ def add_jwt_header_arg(
     )
 
 
+def add_refresh_jwt_header_arg(
+    parser: RequestParser,
+):
+    add_jwt_header_arg(
+        parser=parser,
+        description="Refresh token required to access this endpoint",
+        default_name="YOUR_REFRESH_TOKEN",
+    )
+
+
 def add_password_reset_token_header_arg(
     parser: RequestParser,
 ):
     add_jwt_header_arg(
         parser=parser,
         description="Password Reset token required to access this endpoint",
-        default_name="Bearer YOUR_PASSWORD_RESET_TOKEN",
+        default_name="YOUR_PASSWORD_RESET_TOKEN",
     )
 
 
@@ -53,7 +63,7 @@ def add_validate_email_header_arg(
     add_jwt_header_arg(
         parser=parser,
         description="Email validation token required to access this endpoint",
-        default_name="Bearer YOUR_EMAIL_VALIDATION_TOKEN",
+        default_name="YOUR_EMAIL_VALIDATION_TOKEN",
     )
 
 

--- a/tests/integration/test_refresh_session.py
+++ b/tests/integration/test_refresh_session.py
@@ -34,8 +34,7 @@ def test_refresh_session_post(test_data_creator_flask: TestDataCreatorFlask):
         flask_client=tdc.flask_client,
         http_method="post",
         endpoint="/api/auth/refresh-session",
-        headers=admin_tus.jwt_authorization_header,
-        json={"refresh_token": jwt_tokens.refresh_token},
+        headers={"Authorization": f"Bearer {jwt_tokens.refresh_token}"},
     )
 
     new_access_token = response_json.get("access_token")
@@ -58,22 +57,20 @@ def test_refresh_session_post(test_data_creator_flask: TestDataCreatorFlask):
     )
 
 
-def test_refresh_session_post_invalid_refresh_token(
+def test_refresh_session_post_access_token(
     test_data_creator_flask: TestDataCreatorFlask,
 ):
     tdc = test_data_creator_flask
-    admin_tus = tdc.get_admin_tus()
 
     standard_tus = tdc.standard_user()
 
     jwt_tokens = login_and_return_jwt_tokens(tdc.flask_client, standard_tus.user_info)
 
-    # Test that refresh session fails when the refresh token is invalid
-    response_json = run_and_validate_request(
+    # Test that refresh session fails when the access token is used
+    run_and_validate_request(
         flask_client=tdc.flask_client,
         http_method="post",
         endpoint="/api/auth/refresh-session",
-        headers=admin_tus.jwt_authorization_header,
-        json={"refresh_token": f"{jwt_tokens.refresh_token}"},
-        expected_response_status=HTTPStatus.UNAUTHORIZED,
+        headers={"Authorization": f"Bearer {jwt_tokens.access_token}"},
+        expected_response_status=HTTPStatus.BAD_REQUEST,
     )

--- a/tests/middleware/test_user_queries.py
+++ b/tests/middleware/test_user_queries.py
@@ -89,7 +89,9 @@ def setup_try_logging_in_mocks(check_password_hash_return_value):
 
 def assert_try_logging_in_preconditions(mock):
     mock.db_client.get_user_info.assert_called_with(mock.dto.email)
-    mock.check_password_hash.assert_called_with(mock.password_digest, mock.dto.password)
+    mock.check_password_hash.assert_called_with(
+        pwhash=mock.password_digest, password=mock.dto.password
+    )
 
 
 def test_try_logging_in_successful():


### PR DESCRIPTION
### Fixes

* https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/566

### Description

* Revamp `/refresh-session` endpoint to utilize refresh token only and not access token.

### Testing

* Run tests to confirm functionality
* Confirm can only refresh using refresh token -- not with access token

### Performance

* Impact marginal

### Docs

* API documentation updated 

### Breaking Changes

* BREAKING CHANGE: Prior means of refreshing sessions will not work -- the refresh token will have to be provided in the `authorization` header, and no access token should be provided
