### PR TITLE
feat(api): add `/metadata/record-types-and-categories` endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -19,6 +19,7 @@ from resources.Locations import namespace_locations
 from resources.LoginWithGithub import namespace_login_with_github
 from resources.Map import namespace_map
 from resources.Match import namespace_match
+from resources.Metadata import namespace_metadata
 from resources.Metrics import namespace_metrics
 from resources.Notifications import namespace_notifications
 from resources.OAuth import namespace_oauth
@@ -76,6 +77,7 @@ NAMESPACES = [
     namespace_metrics,
     namespace_admin,
     namespace_contact,
+    namespace_metadata,
 ]
 
 MY_PREFIX = "/api"

--- a/database_client/database_client.py
+++ b/database_client/database_client.py
@@ -1767,3 +1767,33 @@ class DatabaseClient:
         for row in result:
             d[row["Count Type"]] = row["count"]
         return d
+
+    @session_manager
+    def get_record_types_and_categories(self):
+        query = (
+            select(RecordCategory)
+            .options(selectinload(RecordCategory.record_types))
+            .order_by(RecordCategory.id)
+        )
+
+        results: list[RecordCategory] = self.session.execute(query).scalars().all()
+
+        record_types = []
+        record_categories = []
+        for result in results:
+            record_cat_dict = {
+                "id": result.id,
+                "name": result.name,
+                "description": result.description,
+            }
+            record_categories.append(record_cat_dict)
+            for record_type in result.record_types:
+                record_type_dict = {
+                    "id": record_type.id,
+                    "name": record_type.name,
+                    "category_id": record_type.category_id,
+                    "description": record_type.description,
+                }
+                record_types.append(record_type_dict)
+
+        return {"record_types": record_types, "record_categories": record_categories}

--- a/database_client/models.py
+++ b/database_client/models.py
@@ -592,6 +592,12 @@ class RecordCategory(Base):
     name: Mapped[str_255]
     description: Mapped[Optional[text]]
 
+    # Relationships
+    record_types: Mapped[list["RecordType"]] = relationship(
+        argument="RecordType",
+        back_populates="record_categories",
+    )
+
 
 class RecordType(Base):
     __tablename__ = Relations.RECORD_TYPES.value
@@ -600,6 +606,12 @@ class RecordType(Base):
     name: Mapped[str_255]
     category_id: Mapped[int] = mapped_column(ForeignKey("public.record_categories.id"))
     description: Mapped[Optional[text]]
+
+    # Relationships
+    record_categories: Mapped[list[RecordCategory]] = relationship(
+        argument="RecordCategory",
+        back_populates="record_types",
+    )
 
 
 class ResetToken(Base):

--- a/middleware/primary_resource_logic/metadata_logic.py
+++ b/middleware/primary_resource_logic/metadata_logic.py
@@ -1,0 +1,7 @@
+from database_client.database_client import DatabaseClient
+
+
+def get_record_types_and_categories(
+    db_client: DatabaseClient,
+):
+    return db_client.get_record_types_and_categories()

--- a/middleware/schema_and_dto_logic/primary_resource_schemas/record_type_and_category_schemas.py
+++ b/middleware/schema_and_dto_logic/primary_resource_schemas/record_type_and_category_schemas.py
@@ -1,0 +1,54 @@
+from marshmallow import Schema, fields
+
+from middleware.schema_and_dto_logic.util import get_json_metadata
+
+
+class RecordTypeSchema(Schema):
+    id = fields.Integer(
+        required=True, metadata=get_json_metadata("The id of the record type")
+    )
+    name = fields.String(
+        required=True, metadata=get_json_metadata("The name of the record type")
+    )
+    description = fields.String(
+        required=True, metadata=get_json_metadata("The description of the record type")
+    )
+    category_id = fields.Integer(
+        required=True,
+        metadata=get_json_metadata(
+            "The id of the record category the record type is a part of"
+        ),
+    )
+
+
+class RecordCategorySchema(Schema):
+    id = fields.Integer(
+        required=True, metadata=get_json_metadata("The id of the record category")
+    )
+    name = fields.String(
+        required=True, metadata=get_json_metadata("The name of the record category")
+    )
+    description = fields.String(
+        required=True,
+        allow_none=True,
+        metadata=get_json_metadata("The description of the record category"),
+    )
+
+
+class RecordTypeAndCategoryResponseSchema(Schema):
+    record_types = fields.List(
+        cls_or_instance=fields.Nested(
+            RecordTypeSchema(),
+            required=True,
+            metadata=get_json_metadata("The list of record types"),
+        ),
+        metadata=get_json_metadata("The list of record types"),
+    )
+    record_categories = fields.List(
+        cls_or_instance=fields.Nested(
+            RecordCategorySchema(),
+            required=True,
+            metadata=get_json_metadata("The list of record categories"),
+        ),
+        metadata=get_json_metadata("The list of record categories"),
+    )

--- a/resources/Metadata.py
+++ b/resources/Metadata.py
@@ -1,0 +1,31 @@
+from flask import Response
+
+from middleware.access_logic import AccessInfoPrimary, API_OR_JWT_AUTH_INFO
+from middleware.decorators import endpoint_info
+from middleware.primary_resource_logic.metadata_logic import (
+    get_record_types_and_categories,
+)
+from resources.PsycopgResource import PsycopgResource
+from resources.endpoint_schema_config import SchemaConfigs
+from resources.resource_helpers import ResponseInfo
+from utilities.namespace import create_namespace, AppNamespaces
+
+namespace_metadata = create_namespace(AppNamespaces.METADATA)
+
+
+@namespace_metadata.route("/record-types-and-categories", methods=["GET"])
+class RecordTypeAndCategory(PsycopgResource):
+
+    @endpoint_info(
+        namespace=namespace_metadata,
+        auth_info=API_OR_JWT_AUTH_INFO,
+        schema_config=SchemaConfigs.RECORD_TYPE_AND_CATEGORY_GET,
+        response_info=ResponseInfo(
+            success_message="Returns a list of record types and categories."
+        ),
+        description="Get a list of record types and categories",
+    )
+    def get(self, access_info: AccessInfoPrimary) -> Response:
+        return self.run_endpoint(
+            wrapper_function=get_record_types_and_categories,
+        )

--- a/resources/endpoint_schema_config.py
+++ b/resources/endpoint_schema_config.py
@@ -60,6 +60,9 @@ from middleware.schema_and_dto_logic.primary_resource_schemas.match_schemas impo
 from middleware.schema_and_dto_logic.primary_resource_schemas.metrics_schemas import (
     MetricsGetResponseSchema,
 )
+from middleware.schema_and_dto_logic.primary_resource_schemas.record_type_and_category_schemas import (
+    RecordTypeAndCategoryResponseSchema,
+)
 from middleware.schema_and_dto_logic.primary_resource_schemas.reset_token_schemas import (
     ResetPasswordSchema,
 )
@@ -616,3 +619,8 @@ class SchemaConfigs(Enum):
     )
 
     # endregion
+
+    # region Metadata
+    RECORD_TYPE_AND_CATEGORY_GET = EndpointSchemaConfig(
+        primary_output_schema=RecordTypeAndCategoryResponseSchema(),
+    )

--- a/tests/helper_scripts/helper_classes/RequestValidator.py
+++ b/tests/helper_scripts/helper_classes/RequestValidator.py
@@ -781,4 +781,11 @@ class RequestValidator:
             expected_schema=SchemaConfigs.ADMIN_USERS_BY_ID_PUT.value.primary_output_schema,
         )
 
+    def get_record_types_and_categories(self, headers: dict):
+        return self.get(
+            endpoint="/api/metadata/record-types-and-categories",
+            headers=headers,
+            expected_schema=SchemaConfigs.RECORD_TYPE_AND_CATEGORY_GET.value.primary_output_schema,
+        )
+
     # endregion

--- a/tests/integration/test_metadata.py
+++ b/tests/integration/test_metadata.py
@@ -1,0 +1,14 @@
+from tests.helper_scripts.helper_classes.TestDataCreatorFlask import (
+    TestDataCreatorFlask,
+)
+
+
+def test_record_types_and_categories_get(test_data_creator_flask: TestDataCreatorFlask):
+    tdc = test_data_creator_flask
+
+    response_json = tdc.request_validator.get_record_types_and_categories(
+        headers=tdc.get_admin_tus().api_authorization_header
+    )
+
+    print(response_json)
+    assert len(response_json) > 0

--- a/utilities/namespace.py
+++ b/utilities/namespace.py
@@ -35,6 +35,7 @@ class AppNamespaces(Enum):
     METRICS = NamespaceAttributes(path="metrics", description="Metrics Namespace")
     ADMIN = NamespaceAttributes(path="admin", description="Admin Namespace")
     CONTACT = NamespaceAttributes(path="contact", description="Contact Namespace")
+    METADATA = NamespaceAttributes(path="metadata", description="Metadata Namespace")
 
 
 def create_namespace(


### PR DESCRIPTION
### Fixes

* https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/628

### Description

* Add `/metadata/record-types-and-categories` endpoint, which provides a list of all record types and categories.

### Testing

* Run tests and confirm functionality of endpoint

### Performance

* Separate endpoint
* Slight increase in test overhead.

### Docs

* API documentation updated.

### Breaking Changes

* No breaking changes 