### PR TITLE
fix(database): remove name_ascii column from counties table

### DIFF
--- a/alembic/versions/2025_02_27_1241-56cb102b061e_remove_name_ascii_from_counties_table.py
+++ b/alembic/versions/2025_02_27_1241-56cb102b061e_remove_name_ascii_from_counties_table.py
@@ -1,0 +1,27 @@
+"""Remove name_ascii from counties table
+
+Revision ID: 56cb102b061e
+Revises: 4713a996cf91
+Create Date: 2025-02-27 12:41:30.007249
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "56cb102b061e"
+down_revision: Union[str, None] = "4713a996cf91"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.drop_column("counties", "name_ascii")
+
+
+def downgrade() -> None:
+    op.add_column("counties", sa.Column("name_ascii", sa.Text, nullable=True))

--- a/database_client/models.py
+++ b/database_client/models.py
@@ -293,7 +293,6 @@ class County(Base):
     id: Mapped[int] = mapped_column(primary_key=True)
     fips: Mapped[str]
     name: Mapped[Optional[text]]
-    name_ascii: Mapped[Optional[text]]
     state_iso: Mapped[Optional[text]]
     lat: Mapped[Optional[float]]
     lng: Mapped[Optional[float]]

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1021,7 +1021,7 @@ def test_counties_table_log_logic(test_data_creator_db_client: TestDataCreatorDB
     log = logs[1]
     assert log["operation_type"] == OperationType.DELETE.value
     assert log["affected_id"] == county_id
-    assert len(list(log["old_data"].keys())) == 11
+    assert len(list(log["old_data"].keys())) == 10
     assert log["new_data"] is None
 
 


### PR DESCRIPTION
### Fixes

* https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/618

### Description

* Removes `name_ascii` column from `counties` table

### Testing

* Run tests to ensure all pass

### Performance

* No performance impact

### Docs

* No documentation changes

### Breaking Changes

* No breaking changes -- `name_ascii` was never used. 