### PR TITLE
fix(database): remove agencies approved and add approval_status column

### DIFF
--- a/alembic/versions/2025_02_27_1307-203f11778425_add_agencies_approval_status_column_and_.py
+++ b/alembic/versions/2025_02_27_1307-203f11778425_add_agencies_approval_status_column_and_.py
@@ -1,0 +1,127 @@
+"""Add agencies approval_status column and remove approved column
+
+Revision ID: 203f11778425
+Revises: 56cb102b061e
+Create Date: 2025-02-27 13:07:47.967963
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "203f11778425"
+down_revision: Union[str, None] = "56cb102b061e"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+approval_status_enum = sa.Enum(
+    "rejected", "approved", "needs identification", "pending", name="approval_status"
+)
+
+
+def upgrade() -> None:
+    op.execute("DROP VIEW IF EXISTS agencies_expanded")
+    op.add_column(
+        "agencies",
+        sa.Column(
+            "approval_status",
+            approval_status_enum,
+            nullable=False,
+            server_default="pending",
+        ),
+    )
+    op.execute(
+        """
+        UPDATE AGENCIES
+        SET approval_status = 
+            CASE 
+                WHEN approved = TRUE THEN 'approved'::approval_status
+                ELSE 'pending'::approval_status
+            END
+    """
+    )
+    op.drop_column("agencies", "approved")
+    op.execute(
+        """
+    CREATE OR REPLACE VIEW public.agencies_expanded
+ AS
+ SELECT a.name,
+    a.name AS submitted_name,
+    a.homepage_url,
+    a.jurisdiction_type,
+    l.state_iso,
+    l.state_name,
+    l.county_fips,
+    l.county_name,
+    a.lat,
+    a.lng,
+    a.defunct_year,
+    a.id,
+    a.agency_type,
+    a.multi_agency,
+    a.no_web_presence,
+    a.airtable_agency_last_modified,
+    a.approval_status,
+    a.rejection_reason,
+    a.last_approval_editor,
+    a.submitter_contact,
+    a.agency_created,
+    l.locality_name
+   FROM agencies a
+     LEFT JOIN locations_expanded l ON a.location_id = l.id;
+    """
+    )
+
+
+def downgrade() -> None:
+    op.add_column(
+        "agencies",
+        sa.Column("approved", sa.Boolean, nullable=False, server_default="FALSE"),
+    )
+    op.execute(
+        """
+        UPDATE AGENCIES
+        SET APPROVED =
+            CASE 
+                WHEN approval_status = 'approved' then TRUE
+                ELSE FALSE
+            END
+    """
+    )
+    op.execute("""DROP VIEW IF EXISTS agencies_expanded""")
+    op.drop_column("agencies", "approval_status")
+    op.execute(
+        """
+        CREATE OR REPLACE VIEW public.agencies_expanded
+     AS
+     SELECT a.name,
+        a.name AS submitted_name,
+        a.homepage_url,
+        a.jurisdiction_type,
+        l.state_iso,
+        l.state_name,
+        l.county_fips,
+        l.county_name,
+        a.lat,
+        a.lng,
+        a.defunct_year,
+        a.id,
+        a.agency_type,
+        a.multi_agency,
+        a.no_web_presence,
+        a.airtable_agency_last_modified,
+        a.approved,
+        a.rejection_reason,
+        a.last_approval_editor,
+        a.submitter_contact,
+        a.agency_created,
+        l.locality_name
+       FROM agencies a
+         LEFT JOIN locations_expanded l ON a.location_id = l.id;
+        """
+    )

--- a/database_client/models.py
+++ b/database_client/models.py
@@ -240,7 +240,7 @@ class Agency(Base, CountMetadata):
     airtable_agency_last_modified: Mapped[timestamp_tz] = mapped_column(
         server_default=func.current_timestamp()
     )
-    approved: Mapped[bool] = mapped_column(server_default=false())
+    approval_status: Mapped[ApprovalStatusLiteral]
     rejection_reason: Mapped[Optional[str]]
     last_approval_editor = Column(String, nullable=True)
     submitter_contact: Mapped[Optional[str]]

--- a/middleware/column_permission_logic.py
+++ b/middleware/column_permission_logic.py
@@ -10,16 +10,211 @@ from middleware.custom_dataclasses import DeferredFunction
 from middleware.enums import PermissionsEnum, AccessTypeEnum
 from middleware.flask_response_manager import FlaskResponseManager
 
+ROLE_COLUMN_PERMISSIONS = {
+    "agencies_expanded": {
+        "name": {"ADMIN": "READ", "STANDARD": "READ"},
+        "submitted_name": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "homepage_url": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "jurisdiction_type": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "state_iso": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "county_fips": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "county_name": {"ADMIN": "READ", "STANDARD": "READ"},
+        "lat": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "lng": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "defunct_year": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "agency_type": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "multi_agency": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "no_web_presence": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "airtable_agency_last_modified": {"ADMIN": "READ", "STANDARD": "READ"},
+        "approval_status": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "rejection_reason": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "last_approval_editor": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "submitter_contact": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "agency_created": {"ADMIN": "READ", "STANDARD": "READ"},
+        "locality_name": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "state_name": {"ADMIN": "READ", "STANDARD": "READ"},
+        "id": {"ADMIN": "READ", "STANDARD": "READ"},
+    },
+    "agencies": {
+        "name": {"STANDARD": "READ", "ADMIN": "WRITE"},
+        "submitted_name": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "homepage_url": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "jurisdiction_type": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "lat": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "lng": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "defunct_year": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "agency_type": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "multi_agency": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "no_web_presence": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "airtable_agency_last_modified": {"ADMIN": "READ", "STANDARD": "READ"},
+        "approval_status": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "rejection_reason": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "last_approval_editor": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "submitter_contact": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "agency_created": {"ADMIN": "READ", "STANDARD": "READ"},
+        "county_airtable_uid": {"ADMIN": "READ", "STANDARD": "READ"},
+        "location_id": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "id": {"ADMIN": "READ", "STANDARD": "READ"},
+        "airtable_uid": {"ADMIN": "NONE", "STANDARD": "NONE"},
+    },
+    "data_requests": {
+        "id": {"ADMIN": "READ", "STANDARD": "READ", "OWNER": "READ"},
+        "submission_notes": {"ADMIN": "WRITE", "STANDARD": "READ", "OWNER": "WRITE"},
+        "request_status": {"ADMIN": "WRITE", "STANDARD": "READ", "OWNER": "READ"},
+        "archive_reason": {"ADMIN": "WRITE", "STANDARD": "NONE", "OWNER": "READ"},
+        "date_created": {"ADMIN": "READ", "STANDARD": "READ", "OWNER": "READ"},
+        "date_status_last_changed": {
+            "ADMIN": "READ",
+            "STANDARD": "READ",
+            "OWNER": "READ",
+        },
+        "creator_user_id": {"ADMIN": "READ", "STANDARD": "NONE", "OWNER": "READ"},
+        "internal_notes": {"ADMIN": "WRITE", "STANDARD": "NONE", "OWNER": "NONE"},
+        "record_types_required": {
+            "ADMIN": "WRITE",
+            "STANDARD": "READ",
+            "OWNER": "READ",
+        },
+        "pdap_response": {"ADMIN": "WRITE", "STANDARD": "READ", "OWNER": "READ"},
+        "coverage_range": {"ADMIN": "WRITE", "STANDARD": "READ", "OWNER": "WRITE"},
+        "data_requirements": {"ADMIN": "WRITE", "STANDARD": "READ", "OWNER": "WRITE"},
+        "request_urgency": {"ADMIN": "WRITE", "STANDARD": "READ", "OWNER": "WRITE"},
+        "title": {"ADMIN": "WRITE", "STANDARD": "READ", "OWNER": "WRITE"},
+        "github_issue_number": {"ADMIN": "WRITE", "STANDARD": "READ", "OWNER": "READ"},
+        "github_issue_url": {"ADMIN": "WRITE", "STANDARD": "READ", "OWNER": "READ"},
+    },
+    "data_requests_expanded": {
+        "id": {"ADMIN": "READ", "STANDARD": "READ", "OWNER": "READ"},
+        "submission_notes": {"ADMIN": "WRITE", "STANDARD": "READ", "OWNER": "WRITE"},
+        "request_status": {"ADMIN": "WRITE", "STANDARD": "READ", "OWNER": "READ"},
+        "archive_reason": {"ADMIN": "WRITE", "STANDARD": "NONE", "OWNER": "READ"},
+        "date_created": {"ADMIN": "READ", "STANDARD": "READ", "OWNER": "READ"},
+        "date_status_last_changed": {
+            "ADMIN": "READ",
+            "STANDARD": "READ",
+            "OWNER": "READ",
+        },
+        "creator_user_id": {"ADMIN": "READ", "STANDARD": "NONE", "OWNER": "READ"},
+        "internal_notes": {"ADMIN": "WRITE", "STANDARD": "NONE", "OWNER": "NONE"},
+        "record_types_required": {
+            "ADMIN": "WRITE",
+            "STANDARD": "READ",
+            "OWNER": "READ",
+        },
+        "pdap_response": {"ADMIN": "WRITE", "STANDARD": "READ", "OWNER": "READ"},
+        "coverage_range": {"ADMIN": "WRITE", "STANDARD": "READ", "OWNER": "WRITE"},
+        "data_requirements": {"ADMIN": "WRITE", "STANDARD": "READ", "OWNER": "WRITE"},
+        "request_urgency": {"ADMIN": "WRITE", "STANDARD": "READ", "OWNER": "WRITE"},
+        "github_issue_number": {"ADMIN": "WRITE", "STANDARD": "READ", "OWNER": "READ"},
+        "github_issue_url": {"ADMIN": "WRITE", "STANDARD": "READ", "OWNER": "READ"},
+        "title": {"ADMIN": "WRITE", "STANDARD": "READ", "OWNER": "WRITE"},
+    },
+    "data_sources_expanded": {
+        "name": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "submitted_name": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "description": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "source_url": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "agency_supplied": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "supplying_entity": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "agency_originated": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "agency_aggregation": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "coverage_start": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "coverage_end": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "detail_level": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "data_portal_type": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "record_formats": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "update_method": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "tags": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "readme_url": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "originating_entity": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "retention_schedule": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "scraper_url": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "submission_notes": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "rejection_note": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "last_approval_editor": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "submitter_contact_info": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "agency_described_submitted": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "agency_described_not_in_database": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "data_portal_type_other": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "data_source_request": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "broken_source_url_as_of": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "access_notes": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "url_status": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "approval_status": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "record_type_id": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "record_type_name": {"ADMIN": "READ", "STANDARD": "READ"},
+        "access_types": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "updated_at": {"ADMIN": "READ", "STANDARD": "READ"},
+        "created_at": {"ADMIN": "READ", "STANDARD": "READ"},
+        "id": {"ADMIN": "READ", "STANDARD": "READ"},
+        "approval_status_updated_at": {"ADMIN": "READ", "STANDARD": "READ"},
+    },
+    "data_sources": {
+        "name": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "submitted_name": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "description": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "source_url": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "agency_supplied": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "supplying_entity": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "agency_originated": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "agency_aggregation": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "coverage_start": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "coverage_end": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "detail_level": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "data_portal_type": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "record_formats": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "update_method": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "tags": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "readme_url": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "originating_entity": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "retention_schedule": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "scraper_url": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "submission_notes": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "rejection_note": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "last_approval_editor": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "submitter_contact_info": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "agency_described_submitted": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "agency_described_not_in_database": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "data_portal_type_other": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "data_source_request": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "broken_source_url_as_of": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "access_notes": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "url_status": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "approval_status": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "record_type_id": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "access_types": {"ADMIN": "WRITE", "STANDARD": "READ"},
+        "updated_at": {"ADMIN": "READ", "STANDARD": "READ"},
+        "created_at": {"ADMIN": "READ", "STANDARD": "READ"},
+        "id": {"ADMIN": "READ", "STANDARD": "READ"},
+        "approval_status_updated_at": {"ADMIN": "READ", "STANDARD": "READ"},
+        "airtable_uid": {"ADMIN": "NONE", "STANDARD": "NONE"},
+    },
+}
+
 
 def get_permitted_columns(
     db_client: DatabaseClient,
     relation: str,
     role: RelationRoleEnum,
-    column_permission: ColumnPermissionEnum,
+    user_permission: ColumnPermissionEnum,
 ) -> list[str]:
-    return db_client.get_permitted_columns(
-        relation=relation, role=role, column_permission=column_permission
-    )
+    columns_for_permission = []
+    all_columns = ROLE_COLUMN_PERMISSIONS[relation]
+    for column_name, column_permissions in all_columns.items():
+        role_permission = column_permissions[role.value]
+        approved = False
+        if user_permission.value == "WRITE":
+            # User can only write to columns marked as WRITE
+            if role_permission == "WRITE":
+                approved = True
+        elif user_permission.value == "READ":
+            # Use can read any column not marked as NONE
+            if role_permission != "NONE":
+                approved = True
+        if approved:
+            columns_for_permission.append(column_name)
+
+    return columns_for_permission
 
 
 def get_invalid_columns(
@@ -54,7 +249,7 @@ def check_has_permission_to_edit_columns(
         db_client=db_client,
         relation=relation,
         role=role,
-        column_permission=ColumnPermissionEnum.WRITE,
+        user_permission=ColumnPermissionEnum.WRITE,
     )
     invalid_columns = get_invalid_columns(
         requested_columns=columns, permitted_columns=writeable_columns

--- a/middleware/dynamic_request_logic/common_functions.py
+++ b/middleware/dynamic_request_logic/common_functions.py
@@ -46,6 +46,6 @@ def optionally_get_permitted_columns_to_subquery_parameters_(
                     db_client=mp.db_client,
                     relation=parameter.relation_name,
                     role=relation_role,
-                    column_permission=ColumnPermissionEnum.READ,
+                    user_permission=ColumnPermissionEnum.READ,
                 )
             )

--- a/middleware/dynamic_request_logic/get_by_id_logic.py
+++ b/middleware/dynamic_request_logic/get_by_id_logic.py
@@ -77,7 +77,7 @@ def get_by_id(
         db_client=mp.db_client,
         relation=mp.relation,
         role=relation_role,
-        column_permission=ColumnPermissionEnum.READ,
+        user_permission=ColumnPermissionEnum.READ,
     )
     # TODO: Extract to separate function
     optionally_get_permitted_columns_to_subquery_parameters_(mp, relation_role)

--- a/middleware/dynamic_request_logic/get_many_logic.py
+++ b/middleware/dynamic_request_logic/get_many_logic.py
@@ -40,7 +40,7 @@ def get_many(
         db_client=mp.db_client,
         relation=mp.relation,
         role=relation_role,
-        column_permission=ColumnPermissionEnum.READ,
+        user_permission=ColumnPermissionEnum.READ,
     )
 
     permitted_columns = optionally_limit_to_requested_columns(

--- a/middleware/dynamic_request_logic/get_related_resource_logic.py
+++ b/middleware/dynamic_request_logic/get_related_resource_logic.py
@@ -48,7 +48,7 @@ def get_related_resource(
             db_client=gerp.db_client,
             relation=gerp.related_relation.value,
             role=RelationRoleEnum.STANDARD,
-            column_permission=ColumnPermissionEnum.READ,
+            user_permission=ColumnPermissionEnum.READ,
         )
     subquery_parameters = [
         SubqueryParameterManager.get_subquery_params(

--- a/middleware/primary_resource_logic/data_requests.py
+++ b/middleware/primary_resource_logic/data_requests.py
@@ -219,7 +219,7 @@ def get_data_requests_with_permitted_columns(
         db_client=db_client,
         relation=RELATION,
         role=relation_role,
-        column_permission=ColumnPermissionEnum.READ,
+        user_permission=ColumnPermissionEnum.READ,
     )
     data_requests = db_client.get_data_requests(
         columns=columns,

--- a/middleware/primary_resource_logic/locations_logic.py
+++ b/middleware/primary_resource_logic/locations_logic.py
@@ -42,7 +42,7 @@ def get_locations_related_data_requests_wrapper(
             db_client=db_client,
             relation=Relations.DATA_REQUESTS_EXPANDED.value,
             role=get_relation_role(access_info=access_info),
-            column_permission=ColumnPermissionEnum.READ,
+            user_permission=ColumnPermissionEnum.READ,
         ),
         build_metadata=True,
         subquery_parameters=get_data_requests_subquery_params(),

--- a/middleware/schema_and_dto_logic/primary_resource_dtos/agencies_dtos.py
+++ b/middleware/schema_and_dto_logic/primary_resource_dtos/agencies_dtos.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+from database_client.enums import ApprovalStatus
 from middleware.enums import JurisdictionType, AgencyType
 from middleware.schema_and_dto_logic.common_schemas_and_dtos import (
     LocationInfoDTO,
@@ -14,7 +15,7 @@ class AgencyInfoPutDTO(BaseModel):
     agency_type: AgencyType = None
     multi_agency: bool = False
     no_web_presence: bool = False
-    approved: bool = False
+    approval_status: ApprovalStatus = ApprovalStatus.PENDING
     homepage_url: str = None
     lat: float = None
     lng: float = None
@@ -30,7 +31,7 @@ class AgencyInfoPostDTO(BaseModel):
     agency_type: AgencyType
     multi_agency: bool = False
     no_web_presence: bool = False
-    approved: bool = False
+    approval_status: ApprovalStatus = ApprovalStatus.PENDING
     homepage_url: Optional[str] = None
     lat: Optional[float] = None
     lng: Optional[float] = None

--- a/middleware/schema_and_dto_logic/primary_resource_schemas/agencies_base_schemas.py
+++ b/middleware/schema_and_dto_logic/primary_resource_schemas/agencies_base_schemas.py
@@ -1,5 +1,6 @@
 from marshmallow import fields, Schema
 
+from database_client.enums import ApprovalStatus
 from middleware.enums import JurisdictionType, AgencyType
 from middleware.schema_and_dto_logic.primary_resource_schemas.locations_schemas import (
     STATE_ISO_FIELD,
@@ -99,11 +100,13 @@ class AgencyInfoBaseSchema(Schema):
             "csv_column_name": CSVColumnCondition.SAME_AS_FIELD,
         },
     )
-    approved = fields.Bool(
+    approval_status = fields.Enum(
+        enum=ApprovalStatus,
+        by_value=True,
         required=False,
-        load_default=False,
+        load_default=ApprovalStatus.PENDING.value,
         metadata={
-            "description": "Whether the agency is approved.",
+            "description": "Approval status of the agency.",
             "source": SourceMappingEnum.JSON,
         },
     )

--- a/tests/integration/test_search.py
+++ b/tests/integration/test_search.py
@@ -433,7 +433,7 @@ def test_search_federal(test_data_creator_flask: TestDataCreatorFlask):
                     schema=AgencyInfoPostSchema(),
                     override={
                         "jurisdiction_type": JurisdictionType.FEDERAL.value,
-                        "approved": True,
+                        "approval_status": ApprovalStatus.APPROVED.value,
                         "agency_type": AgencyType.POLICE.value,
                     },
                 ),

--- a/tests/middleware/test_column_permission_logic.py
+++ b/tests/middleware/test_column_permission_logic.py
@@ -16,68 +16,6 @@ from middleware.custom_dataclasses import DeferredFunction
 from middleware.enums import PermissionsEnum, AccessTypeEnum
 
 
-def test_get_permitted_columns():
-    mock = MagicMock()
-
-    get_permitted_columns(
-        db_client=mock.db_client,
-        relation=mock.relation,
-        role=mock.role,
-        column_permission=mock.column_permission,
-    )
-
-    mock.db_client.get_permitted_columns.assert_called_once_with(
-        relation=mock.relation, role=mock.role, column_permission=mock.column_permission
-    )
-
-
-@pytest.fixture
-def mock_abort(monkeypatch):
-    mock = MagicMock()
-    monkeypatch.setattr("middleware.flask_response_manager.abort", mock)
-    return mock
-
-
-def test_check_has_permission_to_edit_columns_success(mock_abort):
-    mock = MagicMock()
-    mock.db_client.get_permitted_columns.return_value = ["column_a", "column_b"]
-
-    check_has_permission_to_edit_columns(
-        db_client=mock.db_client,
-        relation=mock.relation,
-        role=mock.role,
-        columns=["column_a", "column_b"],
-    )
-
-    mock_abort.assert_not_called()
-
-    mock.db_client.get_permitted_columns.assert_called_once_with(
-        relation=mock.relation,
-        role=mock.role,
-        column_permission=ColumnPermissionEnum.WRITE,
-    )
-
-
-def test_check_has_permission_to_edit_columns_fail(mock_abort):
-    mock = MagicMock()
-    mock.db_client.get_permitted_columns.return_value = ["column_a"]
-
-    check_has_permission_to_edit_columns(
-        db_client=mock.db_client,
-        relation=mock.relation,
-        role=mock.role,
-        columns=["column_a", "column_b"],
-    )
-
-    mock.db_client.get_permitted_columns.assert_called_once_with(
-        relation=mock.relation,
-        role=mock.role,
-        column_permission=ColumnPermissionEnum.WRITE,
-    )
-
-    mock_abort.assert_called_once()
-
-
 @patch("middleware.column_permission_logic.DatabaseClient")
 def test_create_column_permissions_string_table(mock_DatabaseClient: MagicMock):
     mock_db_client = MagicMock()

--- a/tests/middleware/test_dynamic_request_logic.py
+++ b/tests/middleware/test_dynamic_request_logic.py
@@ -124,7 +124,7 @@ def test_get_by_id(monkeypatch):
         db_client=mock.mp.db_client,
         relation=mock.mp.relation,
         role=mock.relation_role_parameters.get_relation_role_from_parameters.return_value,
-        column_permission=ColumnPermissionEnum.READ,
+        user_permission=ColumnPermissionEnum.READ,
     )
 
     mock.mp.db_client_method.assert_called_once_with(


### PR DESCRIPTION
### Fixes

* https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/425

### Description

* To align the logic of the `agencies` table with those of other tables regarding how they report their approval status, this commit removes the boolean `approved` column and replaces it with the enum-based `approval_status` column. Rows with an `approved` value of `True` have been set to `approved`; all other values have been marked `pending`.
* Additionally, I modified some of the column permission logic because it was an absolute pain to keep modifying, and the new system is simpler. That will be more thoroughly addressed in https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/630

### Testing

* Run tests and confirm all tests pass.
* Once approved in `dev`, confirm that this does not break the dev client. If it does, modify the dev client prior to pushing to production.

### Performance

* Impact marginal

### Docs

* API documentation has been modified.

### Breaking Changes

* `approved` will no longer be a valid attribute on data sources to pull. Instead `approval_status` will need to be used.
