### PR TITLE
feat(database): rename select agency type values and set to enum in db

### DIFF
--- a/alembic/versions/2025_02_27_1505-89b4dbcb8827_rename_agency_types_jail_to_.py
+++ b/alembic/versions/2025_02_27_1505-89b4dbcb8827_rename_agency_types_jail_to_.py
@@ -1,0 +1,142 @@
+"""Rename agency types jail to incarceration police to law enforcement
+
+Revision ID: 89b4dbcb8827
+Revises: 203f11778425
+Create Date: 2025-02-27 15:05:47.507809
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "89b4dbcb8827"
+down_revision: Union[str, None] = "203f11778425"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+agency_type_enum = sa.Enum(
+    "incarceration",
+    "law enforcement",
+    "aggregated",
+    "court",
+    "unknown",
+    name="agency_type",
+)
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+    UPDATE AGENCIES
+    SET agency_type = 'incarceration'
+    WHERE agency_type = 'jail'
+    """
+    )
+
+    op.execute(
+        """
+    UPDATE AGENCIES
+    SET agency_type = 'law enforcement'
+    WHERE agency_type = 'police'
+    """
+    )
+
+    agency_type_enum.create(op.get_bind())
+
+    op.execute("""DROP VIEW IF EXISTS agencies_expanded""")
+    op.alter_column(
+        "agencies",
+        "agency_type",
+        type_=agency_type_enum,
+        postgresql_using="agency_type::agency_type",
+    )
+    op.execute(
+        """
+        CREATE OR REPLACE VIEW public.agencies_expanded
+     AS
+     SELECT a.name,
+        a.name AS submitted_name,
+        a.homepage_url,
+        a.jurisdiction_type,
+        l.state_iso,
+        l.state_name,
+        l.county_fips,
+        l.county_name,
+        a.lat,
+        a.lng,
+        a.defunct_year,
+        a.id,
+        a.agency_type,
+        a.multi_agency,
+        a.no_web_presence,
+        a.airtable_agency_last_modified,
+        a.approval_status,
+        a.rejection_reason,
+        a.last_approval_editor,
+        a.submitter_contact,
+        a.agency_created,
+        l.locality_name
+       FROM agencies a
+         LEFT JOIN locations_expanded l ON a.location_id = l.id;
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("""DROP VIEW IF EXISTS agencies_expanded""")
+    op.alter_column(
+        "agencies", "agency_type", type_=sa.String, postgresql_using="agency_type::TEXT"
+    )
+
+    agency_type_enum.drop(op.get_bind())
+
+    op.execute(
+        """
+    UPDATE AGENCIES
+    SET agency_type = 'jail'
+    WHERE agency_type = 'incarceration'
+    """
+    )
+
+    op.execute(
+        """
+    UPDATE AGENCIES
+    SET agency_type = 'police'
+    WHERE agency_type = 'law enforcement'
+    """
+    )
+
+    op.execute(
+        """
+        CREATE OR REPLACE VIEW public.agencies_expanded
+     AS
+     SELECT a.name,
+        a.name AS submitted_name,
+        a.homepage_url,
+        a.jurisdiction_type,
+        l.state_iso,
+        l.state_name,
+        l.county_fips,
+        l.county_name,
+        a.lat,
+        a.lng,
+        a.defunct_year,
+        a.id,
+        a.agency_type,
+        a.multi_agency,
+        a.no_web_presence,
+        a.airtable_agency_last_modified,
+        a.approval_status,
+        a.rejection_reason,
+        a.last_approval_editor,
+        a.submitter_contact,
+        a.agency_created,
+        l.locality_name
+       FROM agencies a
+         LEFT JOIN locations_expanded l ON a.location_id = l.id;
+        """
+    )

--- a/database_client/models.py
+++ b/database_client/models.py
@@ -135,7 +135,13 @@ EventTypeLiteral = Literal[
 ]
 EntityTypeLiteral = Literal["Data Request", "Data Source"]
 AgencyAggregationLiteral = Literal["county", "local", "state", "federal"]
-
+AgencyTypeLiteral = Literal[
+    "incarceration",
+    "law enforcement",
+    "aggregated",
+    "court",
+    "unknown",
+]
 
 text = Annotated[Text, None]
 timestamp_tz = Annotated[
@@ -234,7 +240,7 @@ class Agency(Base, CountMetadata):
     lat: Mapped[Optional[float]]
     lng: Mapped[Optional[float]]
     defunct_year: Mapped[Optional[str]]
-    agency_type: Mapped[Optional[str]]
+    agency_type: Mapped[AgencyTypeLiteral]
     multi_agency: Mapped[bool] = mapped_column(server_default=false())
     no_web_presence: Mapped[bool] = mapped_column(server_default=false())
     airtable_agency_last_modified: Mapped[timestamp_tz] = mapped_column(

--- a/middleware/enums.py
+++ b/middleware/enums.py
@@ -137,8 +137,8 @@ class AgencyType(Enum):
 
     AGGREGATED = "aggregated"
     COURT = "court"
-    POLICE = "police"
-    JAIL = "jail"
+    POLICE = "law enforcement"
+    JAIL = "incarceration"
     UNKNOWN = "unknown"
 
 


### PR DESCRIPTION
### Fixes

* https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/629

### Description

The following changes were made to the `agencies.agency_type` column in the database
- `jail` has been renamed `incarceration`
- `police` has been renamed `law enforcement`.
- the column type has been modified to be an enum, rather than a text value

### Testing

* Ensure all automated tests pass
* Inspect database to ensure only expected changes occurred

### Performance

* Impact marginal

### Docs

* No documentation changes

### Breaking Changes

* No breaking changes. 