### PR TITLE
fix(api): refine `/archives` `PUT` limiter to 25/min, 1000/hour

### DIFF
--- a/resources/Archives.py
+++ b/resources/Archives.py
@@ -1,6 +1,7 @@
 from flask import Response, request
 from flask_restx import fields
 
+from config import limiter
 from middleware.access_logic import (
     API_OR_JWT_AUTH_INFO,
     AccessInfoPrimary,
@@ -72,6 +73,7 @@ class Archives(PsycopgResource):
         This will be changed in a later update to conform to the standard JSON schema.
         """,
     )
+    @limiter.limit("25/minute;1000/hour")
     def put(self, access_info: AccessInfoPrimary) -> Response:
         """
         Updates the archive data based on the provided JSON payload.


### PR DESCRIPTION
### Fixes

* Supports https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/608

### Description

* refine `/archives` `PUT` limiter to 25/min, 1000/hour

### Testing

* Run tests to confirm functionality
* Confirm limiter is not as, well, limiting as before 

### Performance

* Impact marginal

### Docs

* No documentation changes

### Breaking Changes

* No breaking changes